### PR TITLE
Remove only /romfs/lyt folder

### DIFF
--- a/SwitchThemesNX/source/fs.cpp
+++ b/SwitchThemesNX/source/fs.cpp
@@ -122,11 +122,11 @@ void RecursiveDeleteFolder(const string &path)
 
 void UninstallTheme()
 {
-	if (filesystem::exists(CfwFolder + "/titles/0100000000001000"))
-		RecursiveDeleteFolder(CfwFolder + "/titles/0100000000001000");
+	if (filesystem::exists(CfwFolder + "/titles/0100000000001000/romfs/lyt"))
+		RecursiveDeleteFolder(CfwFolder + "/titles/0100000000001000/romfs/lyt");
     
-	if (filesystem::exists(CfwFolder + "/titles/0100000000001013"))
-		RecursiveDeleteFolder(CfwFolder + "/titles/0100000000001013");
+	if (filesystem::exists(CfwFolder + "/titles/0100000000001013/romfs/lyt"))
+		RecursiveDeleteFolder(CfwFolder + "/titles/0100000000001013/romfs/lyt");
 }
 
 void CreateThemeStructure(const string &tid)


### PR DESCRIPTION
Do not remove whole folder.
Removing lyt folder is enough for uninstalling nxthemes.
I use /romfs/message for system language translation(EN to KO).