### PR TITLE
flag handling

### DIFF
--- a/SwitchThemesNX/source/fs.cpp
+++ b/SwitchThemesNX/source/fs.cpp
@@ -137,10 +137,10 @@ void CreateThemeStructure(const string &tid)
 	mkdir(path.c_str(), ACCESSPERMS);
 	mkdir((path + "/romfs").c_str(), ACCESSPERMS);
 	mkdir((path + "/romfs/lyt").c_str(), ACCESSPERMS);
-	if (!filesystem::exists(path + "/fsmitm.flag"))
+	if (!filesystem::exists(path + "/flags/fsmitm.flag"))
 	{
 		vector<u8> t; 
-		WriteFile(path + "/fsmitm.flag", t);
+		WriteFile(path + "/flags/fsmitm.flag", t);
 	}		
 }
 


### PR DESCRIPTION
https://github.com/Atmosphere-NX/Atmosphere/blob/master/docs/flags.md

flag handling was changed.
atmosphere and reinx are both changed.

I don't know about sxos. So if sxos does not support this, please do not merge it till sxos being updated.