### PR TITLE
remove unnecessary thing

### DIFF
--- a/SwitchThemesNX/source/fs.cpp
+++ b/SwitchThemesNX/source/fs.cpp
@@ -221,7 +221,6 @@ std::string FindKeyFile() noexcept
 	#define CheckKey(x) if (filesystem::exists(x)) return x;
 	CheckKey("sdmc:/prod.keys");
 	CheckKey("sdmc:/switch/prod.keys");
-	CheckKey("sdmc:/switch/lockpick/prod.keys");
 	CheckKey("sdmc:/themes/prod.keys");
 	CheckKey("sdmc:/goldleaf/keys.dat");
 	CheckKey("sdmc:/goldleaf/prod.keys");


### PR DESCRIPTION
Lockpick has saved keys to /switch not /switch/lockpick since its release.
So whoever used lockpick to dump keys, it must be in /switch