### PR TITLE
This workflow should be worked ,but it's not 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: devkitpro/devkita64:latest
+    steps:
+    - name: Checkout master branch
+      run: git clone --recursive https://github.com/exelix11/SwitchThemeInjector.git $GITHUB_WORKSPACE
+
+    - name: make hactool mbedtls and make all
+      run: |
+        cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/hactool
+        make
+        cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/mbedtls
+        make
+        cd $GITHUB_WORKSPACE/SwitchThemesNX/
+        make
+    - uses: actions/upload-artifact@master
+      with:
+        name: Build
+        path: NXThemesInstaller.nro

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: make hactool mbedtls and make all
       run: |
         cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/hactool
-        make
+        make -f makefile
         cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/mbedtls
         make
         cd $GITHUB_WORKSPACE/SwitchThemesNX/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ jobs:
     - name: make hactool mbedtls and make all
       run: |
         cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/hactool
-        make -f makefile
+        mv makefile Makefile
+        make 
         cd $GITHUB_WORKSPACE/SwitchThemesNX/Libs/mbedtls
         make
         cd $GITHUB_WORKSPACE/SwitchThemesNX/

--- a/SwitchThemesNX/Makefile
+++ b/SwitchThemesNX/Makefile
@@ -32,7 +32,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
-SOURCES		:=	Libs/SOIL source/SwitchTools source/SwitchTools/lockpick source/UI source/UI/imgui source/Platform source/Pages source/Pages/ThemeEntry source/SwitchThemesCommon/SarcLib source/SwitchThemesCommon/Layouts source/SwitchThemesCommon/Layouts/Bflyt source/SwitchThemesCommon/Bntx source/SwitchThemesCommon/Bntx/DDSConv source/SwitchThemesCommon/BinaryReadWrite source/SwitchThemesCommon/Fonts source/SwitchThemesCommon source
+SOURCES		:=	Libs/SOIL source/SwitchTools source/SwitchTools/lockpick source/UI source/UI/imgui source/Platform source/Pages source/Pages/ThemeEntry source/SwitchThemesCommon/SarcLib source/SwitchThemesCommon/Layouts source/SwitchThemesCommon/Layouts/Bflyt source/SwitchThemesCommon/Bntx source/SwitchThemesCommon/Bntx/DDSconv source/SwitchThemesCommon/BinaryReadWrite source/SwitchThemesCommon/Fonts source/SwitchThemesCommon source
 DATA		:=	data
 INCLUDES	:=	include Libs
 EXEFS_SRC	:=	exefs_src


### PR DESCRIPTION
Actually,I want to add a language option for this app. Chinese people like this app so much.They ask me to translate this app.I try to do it .But as you know I cannot pass the link .I thought  it's my environment'fault.because maybe I lost some lib in my computer.
And  I write a workflow in github .As you can see ,it is should be workd ,but it's not .It gave me the fault Exactly as the same as my two computer.
```
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/10.1.0/../../../../aarch64-none-elf/bin/ld: BaseEntry.o: in function `NxEntry::NxThemeGetBgImage()':
BaseEntry.cpp:(.text._ZN7NxEntry17NxThemeGetBgImageEv[_ZN7NxEntry17NxThemeGetBgImageEv]+0x1d8): undefined reference to `DDSConv::ImageToDDS(std::vector<unsigned char, std::allocator<unsigned char> > const&, bool, int, int)'
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/10.1.0/../../../../aarch64-none-elf/bin/ld: BaseEntry.cpp:(.text._ZN7NxEntry17NxThemeGetBgImageEv[_ZN7NxEntry17NxThemeGetBgImageEv]+0x2e8): undefined reference to `DDSConv::GetError[abi:cxx11]()'
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/10.1.0/../../../../aarch64-none-elf/bin/ld: BaseEntry.o: in function `NxEntry::DoInstall(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
BaseEntry.cpp:(.text._ZN7NxEntry9DoInstallEbRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN7NxEntry9DoInstallEbRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1bb8): undefined reference to `DDSConv::ImageToDDS(std::vector<unsigned char, std::allocator<unsigned char> > const&, bool, int, int)'
```

Could you check out the workflow ,and tell me why the workflow can't build pass .