### PR TITLE
Fix news texture for 20.0

### DIFF
--- a/SwitchThemesCommon/PatchTemplate.cs
+++ b/SwitchThemesCommon/PatchTemplate.cs
@@ -348,17 +348,17 @@ namespace SwitchThemes.Common
 #endregion
 
 		public string NxThemeName;
-		public string BntxName;
+		public string[] BntxNames;
 		public UInt32 NewColorFlags;
 		public string FileName;
 		public string PaneName;
 		public int W, H;
 		public LayoutFilePatch patch;
 
-		public TextureReplacement(string name, string bntx, UInt32 cflag, string Fname, string Pname, int w, int h, LayoutFilePatch p)
+		public TextureReplacement(string name, string[] bntxNames, UInt32 cflag, string Fname, string Pname, int w, int h, LayoutFilePatch p)
 		{
 			NxThemeName = name;
-			BntxName = bntx;
+			BntxNames = bntxNames;
 			NewColorFlags = cflag;
 			FileName = Fname;
 			PaneName = Pname;
@@ -366,19 +366,22 @@ namespace SwitchThemes.Common
 			patch = p;
 		}
 
+        // News texture name varies by version
+		readonly static string[] newsTextures = new[] {"RdtIcoNews_00^s", "RdtIcoNews_00_Home^s"};
+
 		readonly public static List<TextureReplacement> ResidentMenu = new List<TextureReplacement>
 		{
-			new TextureReplacement("album",     "RdtIcoPvr_00^s",   0x5050505, "blyt/RdtBtnPvr.bflyt",		"P_Pict_00",		64,56, AlbumPatch),
-			new TextureReplacement("news",      "RdtIcoNews_00^s",  0x5050505, "blyt/RdtBtnNtf.bflyt",		"P_PictNtf_00",		64,56, NtfPatch),
-			new TextureReplacement("shop",      "RdtIcoShop^s",     0x5050505, "blyt/RdtBtnShop.bflyt",		"P_Pict",			64,56, ShopPatch),
-			new TextureReplacement("controller","RdtIcoCtrl_00^s",  0x5050505, "blyt/RdtBtnCtrl.bflyt",		"P_Form",			64,56, CtrlPatch),
-			new TextureReplacement("settings",  "RdtIcoSet^s",      0x5050505, "blyt/RdtBtnSet.bflyt",		"P_Pict",			64,56, SetPatch),
-			new TextureReplacement("power",     "RdtIcoPwrForm^s",  0x5050505, "blyt/RdtBtnPow.bflyt",		"P_Pict_00",		64,56, PowPatch),
+			new TextureReplacement("album",     new[] {"RdtIcoPvr_00^s"},	0x5050505, "blyt/RdtBtnPvr.bflyt",		"P_Pict_00",		64,56, AlbumPatch),
+			new TextureReplacement("news",      newsTextures,				0x5050505, "blyt/RdtBtnNtf.bflyt",		"P_PictNtf_00",		64,56, NtfPatch),
+			new TextureReplacement("shop",      new[] {"RdtIcoShop^s"},		0x5050505, "blyt/RdtBtnShop.bflyt",		"P_Pict",			64,56, ShopPatch),
+			new TextureReplacement("controller",new[] {"RdtIcoCtrl_00^s"},	0x5050505, "blyt/RdtBtnCtrl.bflyt",		"P_Form",			64,56, CtrlPatch),
+			new TextureReplacement("settings",  new[] {"RdtIcoSet^s"},		0x5050505, "blyt/RdtBtnSet.bflyt",		"P_Pict",			64,56, SetPatch),
+			new TextureReplacement("power",     new[] {"RdtIcoPwrForm^s"},	0x5050505, "blyt/RdtBtnPow.bflyt",		"P_Pict_00",		64,56, PowPatch),
 		};
 
 		readonly public static List<TextureReplacement> Entrance = new List<TextureReplacement>
 		{
-			new TextureReplacement("lock",     "EntIcoHome^s",  0x5040302, "blyt/EntBtnResumeSystemApplet.bflyt",     "P_PictHome",184,168, LockPatch),
+			new TextureReplacement("lock",     new[] {"EntIcoHome^s"}, 0x5040302, "blyt/EntBtnResumeSystemApplet.bflyt",     "P_PictHome",184,168, LockPatch),
 		};
 
 		readonly public static Dictionary<string, List<TextureReplacement>> NxNameToList = new Dictionary<string, List<TextureReplacement>>

--- a/SwitchThemesNX/source/Pages/ThemeEntry/NxEntry.hpp
+++ b/SwitchThemesNX/source/Pages/ThemeEntry/NxEntry.hpp
@@ -190,7 +190,7 @@ if (SData.files.count("layout.json"))\
 				if (themeInfo.Target == "home" && SData.files.count("album.dds"))
 				{
 					FileHasBeenPatched = true;
-					if (!Patcher.PatchBntxTexture(SData.files["album.dds"], "RdtIcoPvr_00^s", 0x02000000))
+					if (!Patcher.PatchBntxTexture(SData.files["album.dds"], {"RdtIcoPvr_00^s"}, 0x02000000))
 						DialogBlocking("Album icon patch failed for " + SzsName + "\nThe theme will be installed anyway but may crash.");
 				}
 			}

--- a/SwitchThemesNX/source/SwitchThemesCommon/Layouts/DefaultTemplates.cpp
+++ b/SwitchThemesNX/source/SwitchThemesCommon/Layouts/DefaultTemplates.cpp
@@ -271,17 +271,17 @@ namespace Patches::textureReplacement {
 
 	static vector<TextureReplacement> ResidentMenu
 	{
-		{"album",     "RdtIcoPvr_00^s",   0x5050505, "blyt/RdtBtnPvr.bflyt",     "P_Pict_00",   64,56, GetPatch(AlbumPatch)	},
-		{"news",      "RdtIcoNews_00^s",  0x5050505, "blyt/RdtBtnNtf.bflyt",     "P_PictNtf_00",64,56, GetPatch(NtfPatch)	},
-		{"shop",      "RdtIcoShop^s",     0x5050505, "blyt/RdtBtnShop.bflyt",    "P_Pict",      64,56, GetPatch(ShopPatch)	},
-		{"controller","RdtIcoCtrl_00^s",  0x5050505, "blyt/RdtBtnCtrl.bflyt",    "P_Form",		64,56, GetPatch(CtrlPatch)	},
-		{"settings",  "RdtIcoSet^s",      0x5050505, "blyt/RdtBtnSet.bflyt",     "P_Pict",      64,56, GetPatch(SetPatch)	},
-		{"power",     "RdtIcoPwrForm^s",  0x5050505, "blyt/RdtBtnPow.bflyt",     "P_Pict_00",   64,56, GetPatch(PowPatch)	},
+		{"album",     {"RdtIcoPvr_00^s"},							0x5050505, "blyt/RdtBtnPvr.bflyt",     "P_Pict_00",		64,56, GetPatch(AlbumPatch)	},
+		{"news",      {"RdtIcoNews_00^s", "RdtIcoNews_00_Home^s"},	0x5050505, "blyt/RdtBtnNtf.bflyt",     "P_PictNtf_00",	64,56, GetPatch(NtfPatch)	},
+		{"shop",      {"RdtIcoShop^s"},								0x5050505, "blyt/RdtBtnShop.bflyt",    "P_Pict",		64,56, GetPatch(ShopPatch)	},
+		{"controller",{"RdtIcoCtrl_00^s"},							0x5050505, "blyt/RdtBtnCtrl.bflyt",    "P_Form",		64,56, GetPatch(CtrlPatch)	},
+		{"settings",  {"RdtIcoSet^s"},								0x5050505, "blyt/RdtBtnSet.bflyt",     "P_Pict",		64,56, GetPatch(SetPatch)	},
+		{"power",     {"RdtIcoPwrForm^s"},							0x5050505, "blyt/RdtBtnPow.bflyt",     "P_Pict_00",		64,56, GetPatch(PowPatch)	},
 	};
 
 	static vector<TextureReplacement> Entrance
 	{
-		{"lock",     "EntIcoHome^s",  0x5040302, "blyt/EntBtnResumeSystemApplet.bflyt",  "P_PictHome", 184,168, GetPatch(LockPatch)}
+		{"lock", {"EntIcoHome^s"}, 0x5040302, "blyt/EntBtnResumeSystemApplet.bflyt", "P_PictHome", 184,168, GetPatch(LockPatch)}
 	};
 	
 	unordered_map <string, vector<TextureReplacement>> NxNameToList

--- a/SwitchThemesNX/source/SwitchThemesCommon/Layouts/Patches.hpp
+++ b/SwitchThemesNX/source/SwitchThemesCommon/Layouts/Patches.hpp
@@ -183,7 +183,7 @@ struct PatchTemplate
 struct TextureReplacement 
 {
 	std::string NxThemeName;
-	std::string BntxName;
+	std::vector<std::string> BntxNames;
 	u32 NewColorFlags;
 	std::string FileName;
 	std::string PaneName;

--- a/SwitchThemesNX/source/SwitchThemesCommon/SwitchThemesCommon.hpp
+++ b/SwitchThemesNX/source/SwitchThemesCommon/SwitchThemesCommon.hpp
@@ -30,7 +30,7 @@ namespace SwitchThemesCommon {
 		bool PatchLayouts(const LayoutPatch& patch, const std::string& PartName);
 		bool PatchMainBG(const std::vector<u8>& DDS);
 		bool PatchAppletIcon(const std::vector<u8>& DDS, const std::string& texName);
-		bool PatchBntxTexture(const std::vector<u8>& DDS, const std::string& texName, u32 ChannelData = 0xFFFFFFFF);
+		bool PatchBntxTexture(const std::vector<u8>& DDS, const std::vector<std::string>& texNames, u32 ChannelData = 0xFFFFFFFF);
 		bool PatchBntxTextureAttribs(const std::vector<BntxTexAttribPatch>& patches);
 		PatchTemplate DetectSarc();
 		static PatchTemplate DetectSarc(const SARC::SarcData&);


### PR DESCRIPTION
This fixes the news icon texture replacement for 20.0.

To handle `PatchAppletColorAttrib` (which although legacy should still support the news button on newer firmware), nothing special was needed, just added the new texture names to the list, because missing texture names are automatically skipped.

For texture replacement, I've updated it to take not just a single texture name, but a list (.NET array or std::vector) of texture names used across various firmware. Then when patching, it loops through the names, and patches the first one that is actually present in the target szs file. This felt to me like the simplest approach to handle the texture name varying across releases. 

I've verified that the resulting NSO works fine on both 19.0.1 and 20.0.1, and the texture is properly replace on both. I've not yet tested the c# side beyond making sure they build, but they are pretty equivalent changes to the c++ side ones.