### PR TITLE
Support themeing new applet buttons

### DIFF
--- a/SwitchThemes/Form1.Designer.cs
+++ b/SwitchThemes/Form1.Designer.cs
@@ -28,1221 +28,1260 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
-			this.materialTabControl1 = new MaterialSkin.Controls.MaterialTabControl();
-			this.NXThemePage = new System.Windows.Forms.TabPage();
-			this.materialFlatButton2 = new MaterialSkin.Controls.MaterialFlatButton();
-			this.linkLabel2 = new System.Windows.Forms.LinkLabel();
-			this.AllLayoutsBox = new System.Windows.Forms.ComboBox();
-			this.materialLabel9 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialLabel12 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialLabel16 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialRaisedButton9 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.NxBuilderBuild = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.linkLabel3 = new System.Windows.Forms.LinkLabel();
-			this.HomeMenuPartBox = new System.Windows.Forms.ComboBox();
-			this.materialLabel15 = new MaterialSkin.Controls.MaterialLabel();
-			this.tbImageFile2 = new System.Windows.Forms.TextBox();
-			this.materialLabel11 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialLabel8 = new MaterialSkin.Controls.MaterialLabel();
-			this.grpHomeExtra = new System.Windows.Forms.GroupBox();
-			this.btnApplet6 = new System.Windows.Forms.Button();
-			this.btnApplet5 = new System.Windows.Forms.Button();
-			this.btnApplet4 = new System.Windows.Forms.Button();
-			this.btnApplet3 = new System.Windows.Forms.Button();
-			this.btnApplet2 = new System.Windows.Forms.Button();
-			this.button1 = new System.Windows.Forms.Button();
-			this.btnAlbumIcoHelp = new System.Windows.Forms.Button();
-			this.btnApplet1 = new System.Windows.Forms.Button();
-			this.lblAppletIcons = new MaterialSkin.Controls.MaterialLabel();
-			this.btnOpenCustomLayout = new System.Windows.Forms.Button();
-			this.lblCustomCommonLyt = new MaterialSkin.Controls.MaterialLabel();
-			this.grpLockExtra = new System.Windows.Forms.GroupBox();
-			this.button7 = new System.Windows.Forms.Button();
-			this.btnCustomLock = new System.Windows.Forms.Button();
-			this.lblCustomLock = new MaterialSkin.Controls.MaterialLabel();
-			this.ExtractPage = new System.Windows.Forms.TabPage();
-			this.materialLabel18 = new MaterialSkin.Controls.MaterialLabel();
-			this.ExtractNxthemeBtn = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialLabel14 = new MaterialSkin.Controls.MaterialLabel();
-			this.InfoPage = new System.Windows.Forms.TabPage();
-			this.materialLabel13 = new MaterialSkin.Controls.MaterialLabel();
-			this.SubredditLinkLbl = new System.Windows.Forms.LinkLabel();
-			this.QceanLinkLbl = new System.Windows.Forms.LinkLabel();
-			this.DiscordLinkLbl = new System.Windows.Forms.LinkLabel();
-			this.SupportLinkLbl = new System.Windows.Forms.LinkLabel();
-			this.GithubLinkLbl = new System.Windows.Forms.LinkLabel();
-			this.materialLabel10 = new MaterialSkin.Controls.MaterialLabel();
-			this.tbPatches = new System.Windows.Forms.TextBox();
-			this.InjectPage = new System.Windows.Forms.TabPage();
-			this.lblDetected = new MaterialSkin.Controls.MaterialLabel();
-			this.materialRaisedButton3 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.tbImageFile = new System.Windows.Forms.TextBox();
-			this.materialLabel7 = new MaterialSkin.Controls.MaterialLabel();
-			this.linkLabel1 = new System.Windows.Forms.LinkLabel();
-			this.LayoutPatchList = new System.Windows.Forms.ComboBox();
-			this.materialLabel6 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialFlatButton1 = new MaterialSkin.Controls.MaterialFlatButton();
-			this.materialLabel2 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialRaisedButton2 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialLabel17 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
-			this.AdvancedPage = new System.Windows.Forms.TabPage();
-			this.AdvPanel = new System.Windows.Forms.Panel();
-			this.materialRaisedButton7 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialRaisedButton6 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialRaisedButton4 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialLabel5 = new MaterialSkin.Controls.MaterialLabel();
-			this.SzsFileList = new System.Windows.Forms.ListBox();
-			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.extractToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.materialRaisedButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialRaisedButton5 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.checkBox1 = new System.Windows.Forms.CheckBox();
-			this.materialLabel4 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialTabSelector1 = new MaterialSkin.Controls.MaterialTabSelector();
-			this.lblDebug = new System.Windows.Forms.Label();
-			this.materialTabControl1.SuspendLayout();
-			this.NXThemePage.SuspendLayout();
-			this.grpHomeExtra.SuspendLayout();
-			this.grpLockExtra.SuspendLayout();
-			this.ExtractPage.SuspendLayout();
-			this.InfoPage.SuspendLayout();
-			this.InjectPage.SuspendLayout();
-			this.AdvancedPage.SuspendLayout();
-			this.AdvPanel.SuspendLayout();
-			this.contextMenuStrip1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// materialTabControl1
-			// 
-			this.materialTabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            this.materialTabControl1 = new MaterialSkin.Controls.MaterialTabControl();
+            this.NXThemePage = new System.Windows.Forms.TabPage();
+            this.materialFlatButton2 = new MaterialSkin.Controls.MaterialFlatButton();
+            this.linkLabel2 = new System.Windows.Forms.LinkLabel();
+            this.AllLayoutsBox = new System.Windows.Forms.ComboBox();
+            this.materialLabel9 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel12 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel16 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialRaisedButton9 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.NxBuilderBuild = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.linkLabel3 = new System.Windows.Forms.LinkLabel();
+            this.HomeMenuPartBox = new System.Windows.Forms.ComboBox();
+            this.materialLabel15 = new MaterialSkin.Controls.MaterialLabel();
+            this.tbImageFile2 = new System.Windows.Forms.TextBox();
+            this.materialLabel11 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel8 = new MaterialSkin.Controls.MaterialLabel();
+            this.grpHomeExtra = new System.Windows.Forms.GroupBox();
+            this.btnApplet6 = new System.Windows.Forms.Button();
+            this.btnApplet5 = new System.Windows.Forms.Button();
+            this.btnApplet4 = new System.Windows.Forms.Button();
+            this.btnApplet3 = new System.Windows.Forms.Button();
+            this.btnApplet2 = new System.Windows.Forms.Button();
+            this.button1 = new System.Windows.Forms.Button();
+            this.btnAlbumIcoHelp = new System.Windows.Forms.Button();
+            this.btnApplet1 = new System.Windows.Forms.Button();
+            this.btnApplet7 = new System.Windows.Forms.Button();
+            this.btnApplet8 = new System.Windows.Forms.Button();
+            this.btnApplet9 = new System.Windows.Forms.Button();
+            this.lblAppletIcons = new MaterialSkin.Controls.MaterialLabel();
+            this.btnOpenCustomLayout = new System.Windows.Forms.Button();
+            this.lblCustomCommonLyt = new MaterialSkin.Controls.MaterialLabel();
+            this.grpLockExtra = new System.Windows.Forms.GroupBox();
+            this.button7 = new System.Windows.Forms.Button();
+            this.btnCustomLock = new System.Windows.Forms.Button();
+            this.lblCustomLock = new MaterialSkin.Controls.MaterialLabel();
+            this.ExtractPage = new System.Windows.Forms.TabPage();
+            this.materialLabel18 = new MaterialSkin.Controls.MaterialLabel();
+            this.ExtractNxthemeBtn = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialLabel14 = new MaterialSkin.Controls.MaterialLabel();
+            this.InfoPage = new System.Windows.Forms.TabPage();
+            this.materialLabel13 = new MaterialSkin.Controls.MaterialLabel();
+            this.SubredditLinkLbl = new System.Windows.Forms.LinkLabel();
+            this.QceanLinkLbl = new System.Windows.Forms.LinkLabel();
+            this.DiscordLinkLbl = new System.Windows.Forms.LinkLabel();
+            this.SupportLinkLbl = new System.Windows.Forms.LinkLabel();
+            this.GithubLinkLbl = new System.Windows.Forms.LinkLabel();
+            this.materialLabel10 = new MaterialSkin.Controls.MaterialLabel();
+            this.tbPatches = new System.Windows.Forms.TextBox();
+            this.InjectPage = new System.Windows.Forms.TabPage();
+            this.lblDetected = new MaterialSkin.Controls.MaterialLabel();
+            this.materialRaisedButton3 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.tbImageFile = new System.Windows.Forms.TextBox();
+            this.materialLabel7 = new MaterialSkin.Controls.MaterialLabel();
+            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
+            this.LayoutPatchList = new System.Windows.Forms.ComboBox();
+            this.materialLabel6 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialFlatButton1 = new MaterialSkin.Controls.MaterialFlatButton();
+            this.materialLabel2 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialRaisedButton2 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel17 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
+            this.AdvancedPage = new System.Windows.Forms.TabPage();
+            this.AdvPanel = new System.Windows.Forms.Panel();
+            this.materialRaisedButton7 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialRaisedButton6 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialRaisedButton4 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialLabel5 = new MaterialSkin.Controls.MaterialLabel();
+            this.SzsFileList = new System.Windows.Forms.ListBox();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.extractToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.materialRaisedButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialRaisedButton5 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.materialLabel4 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialTabSelector1 = new MaterialSkin.Controls.MaterialTabSelector();
+            this.lblDebug = new System.Windows.Forms.Label();
+            this.materialTabControl1.SuspendLayout();
+            this.NXThemePage.SuspendLayout();
+            this.grpHomeExtra.SuspendLayout();
+            this.grpLockExtra.SuspendLayout();
+            this.ExtractPage.SuspendLayout();
+            this.InfoPage.SuspendLayout();
+            this.InjectPage.SuspendLayout();
+            this.AdvancedPage.SuspendLayout();
+            this.AdvPanel.SuspendLayout();
+            this.contextMenuStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // materialTabControl1
+            // 
+            this.materialTabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialTabControl1.Controls.Add(this.NXThemePage);
-			this.materialTabControl1.Controls.Add(this.ExtractPage);
-			this.materialTabControl1.Controls.Add(this.InfoPage);
-			this.materialTabControl1.Controls.Add(this.InjectPage);
-			this.materialTabControl1.Controls.Add(this.AdvancedPage);
-			this.materialTabControl1.Depth = 0;
-			this.materialTabControl1.Location = new System.Drawing.Point(-1, 95);
-			this.materialTabControl1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialTabControl1.Name = "materialTabControl1";
-			this.materialTabControl1.SelectedIndex = 0;
-			this.materialTabControl1.Size = new System.Drawing.Size(646, 357);
-			this.materialTabControl1.TabIndex = 4;
-			// 
-			// NXThemePage
-			// 
-			this.NXThemePage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.NXThemePage.Controls.Add(this.materialFlatButton2);
-			this.NXThemePage.Controls.Add(this.linkLabel2);
-			this.NXThemePage.Controls.Add(this.AllLayoutsBox);
-			this.NXThemePage.Controls.Add(this.materialLabel9);
-			this.NXThemePage.Controls.Add(this.materialLabel12);
-			this.NXThemePage.Controls.Add(this.materialLabel16);
-			this.NXThemePage.Controls.Add(this.materialRaisedButton9);
-			this.NXThemePage.Controls.Add(this.NxBuilderBuild);
-			this.NXThemePage.Controls.Add(this.linkLabel3);
-			this.NXThemePage.Controls.Add(this.HomeMenuPartBox);
-			this.NXThemePage.Controls.Add(this.materialLabel15);
-			this.NXThemePage.Controls.Add(this.tbImageFile2);
-			this.NXThemePage.Controls.Add(this.materialLabel11);
-			this.NXThemePage.Controls.Add(this.materialLabel8);
-			this.NXThemePage.Controls.Add(this.grpHomeExtra);
-			this.NXThemePage.Controls.Add(this.grpLockExtra);
-			this.NXThemePage.ForeColor = System.Drawing.Color.White;
-			this.NXThemePage.Location = new System.Drawing.Point(4, 22);
-			this.NXThemePage.Name = "NXThemePage";
-			this.NXThemePage.Padding = new System.Windows.Forms.Padding(3);
-			this.NXThemePage.Size = new System.Drawing.Size(638, 331);
-			this.NXThemePage.TabIndex = 4;
-			this.NXThemePage.Text = "NXTheme builder";
-			// 
-			// materialFlatButton2
-			// 
-			this.materialFlatButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialFlatButton2.AutoSize = true;
-			this.materialFlatButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialFlatButton2.Depth = 0;
-			this.materialFlatButton2.ForeColor = System.Drawing.Color.White;
-			this.materialFlatButton2.Icon = null;
-			this.materialFlatButton2.Location = new System.Drawing.Point(602, 81);
-			this.materialFlatButton2.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-			this.materialFlatButton2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialFlatButton2.Name = "materialFlatButton2";
-			this.materialFlatButton2.Primary = false;
-			this.materialFlatButton2.Size = new System.Drawing.Size(32, 36);
-			this.materialFlatButton2.TabIndex = 2;
-			this.materialFlatButton2.Text = "...";
-			this.materialFlatButton2.UseVisualStyleBackColor = true;
-			this.materialFlatButton2.Click += new System.EventHandler(this.BgImageSelectBtn_Click);
-			this.materialFlatButton2.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
-			this.materialFlatButton2.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// linkLabel2
-			// 
-			this.linkLabel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.linkLabel2.LinkColor = System.Drawing.SystemColors.MenuHighlight;
-			this.linkLabel2.Location = new System.Drawing.Point(545, 147);
-			this.linkLabel2.Name = "linkLabel2";
-			this.linkLabel2.Size = new System.Drawing.Size(84, 21);
-			this.linkLabel2.TabIndex = 4;
-			this.linkLabel2.TabStop = true;
-			this.linkLabel2.Text = "Preview layout";
-			this.linkLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.linkLabel2.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel2_LinkClicked_1);
-			// 
-			// AllLayoutsBox
-			// 
-			this.AllLayoutsBox.AllowDrop = true;
-			this.AllLayoutsBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialTabControl1.Controls.Add(this.NXThemePage);
+            this.materialTabControl1.Controls.Add(this.ExtractPage);
+            this.materialTabControl1.Controls.Add(this.InfoPage);
+            this.materialTabControl1.Controls.Add(this.InjectPage);
+            this.materialTabControl1.Controls.Add(this.AdvancedPage);
+            this.materialTabControl1.Depth = 0;
+            this.materialTabControl1.Location = new System.Drawing.Point(-1, 95);
+            this.materialTabControl1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialTabControl1.Name = "materialTabControl1";
+            this.materialTabControl1.SelectedIndex = 0;
+            this.materialTabControl1.Size = new System.Drawing.Size(715, 400);
+            this.materialTabControl1.TabIndex = 4;
+            // 
+            // NXThemePage
+            // 
+            this.NXThemePage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.NXThemePage.Controls.Add(this.materialFlatButton2);
+            this.NXThemePage.Controls.Add(this.linkLabel2);
+            this.NXThemePage.Controls.Add(this.AllLayoutsBox);
+            this.NXThemePage.Controls.Add(this.materialLabel9);
+            this.NXThemePage.Controls.Add(this.materialLabel12);
+            this.NXThemePage.Controls.Add(this.materialLabel16);
+            this.NXThemePage.Controls.Add(this.materialRaisedButton9);
+            this.NXThemePage.Controls.Add(this.NxBuilderBuild);
+            this.NXThemePage.Controls.Add(this.linkLabel3);
+            this.NXThemePage.Controls.Add(this.HomeMenuPartBox);
+            this.NXThemePage.Controls.Add(this.materialLabel15);
+            this.NXThemePage.Controls.Add(this.tbImageFile2);
+            this.NXThemePage.Controls.Add(this.materialLabel11);
+            this.NXThemePage.Controls.Add(this.materialLabel8);
+            this.NXThemePage.Controls.Add(this.grpHomeExtra);
+            this.NXThemePage.Controls.Add(this.grpLockExtra);
+            this.NXThemePage.ForeColor = System.Drawing.Color.White;
+            this.NXThemePage.Location = new System.Drawing.Point(4, 22);
+            this.NXThemePage.Name = "NXThemePage";
+            this.NXThemePage.Padding = new System.Windows.Forms.Padding(3);
+            this.NXThemePage.Size = new System.Drawing.Size(707, 374);
+            this.NXThemePage.TabIndex = 4;
+            this.NXThemePage.Text = "NXTheme builder";
+            // 
+            // materialFlatButton2
+            // 
+            this.materialFlatButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialFlatButton2.AutoSize = true;
+            this.materialFlatButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialFlatButton2.Depth = 0;
+            this.materialFlatButton2.ForeColor = System.Drawing.Color.White;
+            this.materialFlatButton2.Icon = null;
+            this.materialFlatButton2.Location = new System.Drawing.Point(671, 81);
+            this.materialFlatButton2.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.materialFlatButton2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialFlatButton2.Name = "materialFlatButton2";
+            this.materialFlatButton2.Primary = false;
+            this.materialFlatButton2.Size = new System.Drawing.Size(32, 36);
+            this.materialFlatButton2.TabIndex = 2;
+            this.materialFlatButton2.Text = "...";
+            this.materialFlatButton2.UseVisualStyleBackColor = true;
+            this.materialFlatButton2.Click += new System.EventHandler(this.BgImageSelectBtn_Click);
+            this.materialFlatButton2.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
+            this.materialFlatButton2.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // linkLabel2
+            // 
+            this.linkLabel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.linkLabel2.LinkColor = System.Drawing.SystemColors.MenuHighlight;
+            this.linkLabel2.Location = new System.Drawing.Point(614, 147);
+            this.linkLabel2.Name = "linkLabel2";
+            this.linkLabel2.Size = new System.Drawing.Size(84, 21);
+            this.linkLabel2.TabIndex = 4;
+            this.linkLabel2.TabStop = true;
+            this.linkLabel2.Text = "Preview layout";
+            this.linkLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.linkLabel2.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel2_LinkClicked_1);
+            // 
+            // AllLayoutsBox
+            // 
+            this.AllLayoutsBox.AllowDrop = true;
+            this.AllLayoutsBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.AllLayoutsBox.BackColor = System.Drawing.Color.White;
-			this.AllLayoutsBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.AllLayoutsBox.FormattingEnabled = true;
-			this.AllLayoutsBox.Items.AddRange(new object[] {
+            this.AllLayoutsBox.BackColor = System.Drawing.Color.White;
+            this.AllLayoutsBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.AllLayoutsBox.FormattingEnabled = true;
+            this.AllLayoutsBox.Items.AddRange(new object[] {
             "Don\'t patch"});
-			this.AllLayoutsBox.Location = new System.Drawing.Point(108, 147);
-			this.AllLayoutsBox.Name = "AllLayoutsBox";
-			this.AllLayoutsBox.Size = new System.Drawing.Size(432, 21);
-			this.AllLayoutsBox.TabIndex = 3;
-			this.AllLayoutsBox.SelectedIndexChanged += new System.EventHandler(this.LayoutPatchList_SelectedIndexChanged);
-			this.AllLayoutsBox.DragDrop += new System.Windows.Forms.DragEventHandler(this.LayoutPatchList_DragDrop);
-			this.AllLayoutsBox.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel9
-			// 
-			this.materialLabel9.Depth = 0;
-			this.materialLabel9.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel9.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel9.Location = new System.Drawing.Point(9, 147);
-			this.materialLabel9.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel9.Name = "materialLabel9";
-			this.materialLabel9.Size = new System.Drawing.Size(103, 19);
-			this.materialLabel9.TabIndex = 13;
-			this.materialLabel9.Text = "Layout patch: ";
-			// 
-			// materialLabel12
-			// 
-			this.materialLabel12.Depth = 0;
-			this.materialLabel12.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel12.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel12.Location = new System.Drawing.Point(12, 174);
-			this.materialLabel12.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel12.Name = "materialLabel12";
-			this.materialLabel12.Size = new System.Drawing.Size(617, 24);
-			this.materialLabel12.TabIndex = 17;
-			this.materialLabel12.Text = "Layout compatibility is not automatically checked, test your theme before sharing" +
+            this.AllLayoutsBox.Location = new System.Drawing.Point(108, 147);
+            this.AllLayoutsBox.Name = "AllLayoutsBox";
+            this.AllLayoutsBox.Size = new System.Drawing.Size(501, 21);
+            this.AllLayoutsBox.TabIndex = 3;
+            this.AllLayoutsBox.SelectedIndexChanged += new System.EventHandler(this.LayoutPatchList_SelectedIndexChanged);
+            this.AllLayoutsBox.DragDrop += new System.Windows.Forms.DragEventHandler(this.LayoutPatchList_DragDrop);
+            this.AllLayoutsBox.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel9
+            // 
+            this.materialLabel9.Depth = 0;
+            this.materialLabel9.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel9.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel9.Location = new System.Drawing.Point(9, 147);
+            this.materialLabel9.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel9.Name = "materialLabel9";
+            this.materialLabel9.Size = new System.Drawing.Size(103, 19);
+            this.materialLabel9.TabIndex = 13;
+            this.materialLabel9.Text = "Layout patch: ";
+            // 
+            // materialLabel12
+            // 
+            this.materialLabel12.Depth = 0;
+            this.materialLabel12.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel12.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel12.Location = new System.Drawing.Point(12, 174);
+            this.materialLabel12.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel12.Name = "materialLabel12";
+            this.materialLabel12.Size = new System.Drawing.Size(617, 24);
+            this.materialLabel12.TabIndex = 17;
+            this.materialLabel12.Text = "Layout compatibility is not automatically checked, test your theme before sharing" +
     " it!";
-			this.materialLabel12.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// materialLabel16
-			// 
-			this.materialLabel16.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel12.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // materialLabel16
+            // 
+            this.materialLabel16.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel16.Depth = 0;
-			this.materialLabel16.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel16.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel16.Location = new System.Drawing.Point(13, 116);
-			this.materialLabel16.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel16.Name = "materialLabel16";
-			this.materialLabel16.Size = new System.Drawing.Size(617, 24);
-			this.materialLabel16.TabIndex = 24;
-			this.materialLabel16.Text = "For NXThemes you must use a 720p image (1280x720 pixels)";
-			this.materialLabel16.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// materialRaisedButton9
-			// 
-			this.materialRaisedButton9.AllowDrop = true;
-			this.materialRaisedButton9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialRaisedButton9.AutoSize = true;
-			this.materialRaisedButton9.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton9.Depth = 0;
-			this.materialRaisedButton9.Icon = null;
-			this.materialRaisedButton9.Location = new System.Drawing.Point(356, 288);
-			this.materialRaisedButton9.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton9.Name = "materialRaisedButton9";
-			this.materialRaisedButton9.Primary = true;
-			this.materialRaisedButton9.Size = new System.Drawing.Size(144, 36);
-			this.materialRaisedButton9.TabIndex = 6;
-			this.materialRaisedButton9.Text = "Remote install...";
-			this.materialRaisedButton9.UseVisualStyleBackColor = true;
-			this.materialRaisedButton9.Click += new System.EventHandler(this.materialRaisedButton9_Click);
-			this.materialRaisedButton9.DragDrop += new System.Windows.Forms.DragEventHandler(this.RemoteInstal_DragDrop);
-			this.materialRaisedButton9.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// NxBuilderBuild
-			// 
-			this.NxBuilderBuild.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.NxBuilderBuild.AutoSize = true;
-			this.NxBuilderBuild.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.NxBuilderBuild.Depth = 0;
-			this.NxBuilderBuild.Icon = null;
-			this.NxBuilderBuild.Location = new System.Drawing.Point(506, 288);
-			this.NxBuilderBuild.MouseState = MaterialSkin.MouseState.HOVER;
-			this.NxBuilderBuild.Name = "NxBuilderBuild";
-			this.NxBuilderBuild.Primary = true;
-			this.NxBuilderBuild.Size = new System.Drawing.Size(126, 36);
-			this.NxBuilderBuild.TabIndex = 7;
-			this.NxBuilderBuild.Text = "Build NXTheme";
-			this.NxBuilderBuild.UseVisualStyleBackColor = true;
-			this.NxBuilderBuild.Click += new System.EventHandler(this.NnBuilderBuild_Click);
-			// 
-			// linkLabel3
-			// 
-			this.linkLabel3.Anchor = System.Windows.Forms.AnchorStyles.Top;
-			this.linkLabel3.LinkColor = System.Drawing.SystemColors.MenuHighlight;
-			this.linkLabel3.Location = new System.Drawing.Point(2, 26);
-			this.linkLabel3.Name = "linkLabel3";
-			this.linkLabel3.Size = new System.Drawing.Size(632, 21);
-			this.linkLabel3.TabIndex = 21;
-			this.linkLabel3.TabStop = true;
-			this.linkLabel3.Text = "What is an NXTheme file?";
-			this.linkLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.linkLabel3.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel5_LinkClicked);
-			// 
-			// HomeMenuPartBox
-			// 
-			this.HomeMenuPartBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel16.Depth = 0;
+            this.materialLabel16.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel16.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel16.Location = new System.Drawing.Point(13, 116);
+            this.materialLabel16.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel16.Name = "materialLabel16";
+            this.materialLabel16.Size = new System.Drawing.Size(686, 24);
+            this.materialLabel16.TabIndex = 24;
+            this.materialLabel16.Text = "For NXThemes you must use a 720p image (1280x720 pixels)";
+            this.materialLabel16.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // materialRaisedButton9
+            // 
+            this.materialRaisedButton9.AllowDrop = true;
+            this.materialRaisedButton9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialRaisedButton9.AutoSize = true;
+            this.materialRaisedButton9.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton9.Depth = 0;
+            this.materialRaisedButton9.Icon = null;
+            this.materialRaisedButton9.Location = new System.Drawing.Point(425, 331);
+            this.materialRaisedButton9.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton9.Name = "materialRaisedButton9";
+            this.materialRaisedButton9.Primary = true;
+            this.materialRaisedButton9.Size = new System.Drawing.Size(144, 36);
+            this.materialRaisedButton9.TabIndex = 6;
+            this.materialRaisedButton9.Text = "Remote install...";
+            this.materialRaisedButton9.UseVisualStyleBackColor = true;
+            this.materialRaisedButton9.Click += new System.EventHandler(this.materialRaisedButton9_Click);
+            this.materialRaisedButton9.DragDrop += new System.Windows.Forms.DragEventHandler(this.RemoteInstal_DragDrop);
+            this.materialRaisedButton9.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // NxBuilderBuild
+            // 
+            this.NxBuilderBuild.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.NxBuilderBuild.AutoSize = true;
+            this.NxBuilderBuild.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.NxBuilderBuild.Depth = 0;
+            this.NxBuilderBuild.Icon = null;
+            this.NxBuilderBuild.Location = new System.Drawing.Point(575, 331);
+            this.NxBuilderBuild.MouseState = MaterialSkin.MouseState.HOVER;
+            this.NxBuilderBuild.Name = "NxBuilderBuild";
+            this.NxBuilderBuild.Primary = true;
+            this.NxBuilderBuild.Size = new System.Drawing.Size(126, 36);
+            this.NxBuilderBuild.TabIndex = 7;
+            this.NxBuilderBuild.Text = "Build NXTheme";
+            this.NxBuilderBuild.UseVisualStyleBackColor = true;
+            this.NxBuilderBuild.Click += new System.EventHandler(this.NnBuilderBuild_Click);
+            // 
+            // linkLabel3
+            // 
+            this.linkLabel3.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.linkLabel3.LinkColor = System.Drawing.SystemColors.MenuHighlight;
+            this.linkLabel3.Location = new System.Drawing.Point(36, 26);
+            this.linkLabel3.Name = "linkLabel3";
+            this.linkLabel3.Size = new System.Drawing.Size(632, 21);
+            this.linkLabel3.TabIndex = 21;
+            this.linkLabel3.TabStop = true;
+            this.linkLabel3.Text = "What is an NXTheme file?";
+            this.linkLabel3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.linkLabel3.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel5_LinkClicked);
+            // 
+            // HomeMenuPartBox
+            // 
+            this.HomeMenuPartBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.HomeMenuPartBox.BackColor = System.Drawing.Color.White;
-			this.HomeMenuPartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.HomeMenuPartBox.FormattingEnabled = true;
-			this.HomeMenuPartBox.Location = new System.Drawing.Point(287, 55);
-			this.HomeMenuPartBox.Name = "HomeMenuPartBox";
-			this.HomeMenuPartBox.Size = new System.Drawing.Size(231, 21);
-			this.HomeMenuPartBox.TabIndex = 0;
-			this.HomeMenuPartBox.SelectedIndexChanged += new System.EventHandler(this.HomeMenuPartBox_SelectedIndexChanged);
-			// 
-			// materialLabel15
-			// 
-			this.materialLabel15.Depth = 0;
-			this.materialLabel15.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel15.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel15.Location = new System.Drawing.Point(151, 57);
-			this.materialLabel15.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel15.Name = "materialLabel15";
-			this.materialLabel15.Size = new System.Drawing.Size(133, 19);
-			this.materialLabel15.TabIndex = 19;
-			this.materialLabel15.Text = "Home menu part:";
-			// 
-			// tbImageFile2
-			// 
-			this.tbImageFile2.AllowDrop = true;
-			this.tbImageFile2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.HomeMenuPartBox.BackColor = System.Drawing.Color.White;
+            this.HomeMenuPartBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.HomeMenuPartBox.FormattingEnabled = true;
+            this.HomeMenuPartBox.Location = new System.Drawing.Point(287, 55);
+            this.HomeMenuPartBox.Name = "HomeMenuPartBox";
+            this.HomeMenuPartBox.Size = new System.Drawing.Size(300, 21);
+            this.HomeMenuPartBox.TabIndex = 0;
+            this.HomeMenuPartBox.SelectedIndexChanged += new System.EventHandler(this.HomeMenuPartBox_SelectedIndexChanged);
+            // 
+            // materialLabel15
+            // 
+            this.materialLabel15.Depth = 0;
+            this.materialLabel15.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel15.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel15.Location = new System.Drawing.Point(151, 57);
+            this.materialLabel15.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel15.Name = "materialLabel15";
+            this.materialLabel15.Size = new System.Drawing.Size(133, 19);
+            this.materialLabel15.TabIndex = 19;
+            this.materialLabel15.Text = "Home menu part:";
+            // 
+            // tbImageFile2
+            // 
+            this.tbImageFile2.AllowDrop = true;
+            this.tbImageFile2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbImageFile2.Location = new System.Drawing.Point(67, 90);
-			this.tbImageFile2.Name = "tbImageFile2";
-			this.tbImageFile2.ReadOnly = true;
-			this.tbImageFile2.Size = new System.Drawing.Size(537, 20);
-			this.tbImageFile2.TabIndex = 1;
-			this.tbImageFile2.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
-			this.tbImageFile2.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel11
-			// 
-			this.materialLabel11.Depth = 0;
-			this.materialLabel11.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel11.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel11.Location = new System.Drawing.Point(9, 89);
-			this.materialLabel11.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel11.Name = "materialLabel11";
-			this.materialLabel11.Size = new System.Drawing.Size(63, 19);
-			this.materialLabel11.TabIndex = 11;
-			this.materialLabel11.Text = "Image: ";
-			// 
-			// materialLabel8
-			// 
-			this.materialLabel8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbImageFile2.Location = new System.Drawing.Point(67, 90);
+            this.tbImageFile2.Name = "tbImageFile2";
+            this.tbImageFile2.ReadOnly = true;
+            this.tbImageFile2.Size = new System.Drawing.Size(606, 20);
+            this.tbImageFile2.TabIndex = 1;
+            this.tbImageFile2.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
+            this.tbImageFile2.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel11
+            // 
+            this.materialLabel11.Depth = 0;
+            this.materialLabel11.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel11.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel11.Location = new System.Drawing.Point(9, 89);
+            this.materialLabel11.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel11.Name = "materialLabel11";
+            this.materialLabel11.Size = new System.Drawing.Size(63, 19);
+            this.materialLabel11.TabIndex = 11;
+            this.materialLabel11.Text = "Image: ";
+            // 
+            // materialLabel8
+            // 
+            this.materialLabel8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel8.Depth = 0;
-			this.materialLabel8.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel8.Location = new System.Drawing.Point(2, 3);
-			this.materialLabel8.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel8.Name = "materialLabel8";
-			this.materialLabel8.Size = new System.Drawing.Size(633, 25);
-			this.materialLabel8.TabIndex = 7;
-			this.materialLabel8.Text = "Use this page to create NXTheme files (You don\'t need to open an SZS for this)";
-			this.materialLabel8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// grpHomeExtra
-			// 
-			this.grpHomeExtra.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.materialLabel8.Depth = 0;
+            this.materialLabel8.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel8.Location = new System.Drawing.Point(2, 3);
+            this.materialLabel8.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel8.Name = "materialLabel8";
+            this.materialLabel8.Size = new System.Drawing.Size(702, 25);
+            this.materialLabel8.TabIndex = 7;
+            this.materialLabel8.Text = "Use this page to create NXTheme files (You don\'t need to open an SZS for this)";
+            this.materialLabel8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // grpHomeExtra
+            // 
+            this.grpHomeExtra.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpHomeExtra.Controls.Add(this.btnApplet6);
-			this.grpHomeExtra.Controls.Add(this.btnApplet5);
-			this.grpHomeExtra.Controls.Add(this.btnApplet4);
-			this.grpHomeExtra.Controls.Add(this.btnApplet3);
-			this.grpHomeExtra.Controls.Add(this.btnApplet2);
-			this.grpHomeExtra.Controls.Add(this.button1);
-			this.grpHomeExtra.Controls.Add(this.btnAlbumIcoHelp);
-			this.grpHomeExtra.Controls.Add(this.btnApplet1);
-			this.grpHomeExtra.Controls.Add(this.lblAppletIcons);
-			this.grpHomeExtra.Controls.Add(this.btnOpenCustomLayout);
-			this.grpHomeExtra.Controls.Add(this.lblCustomCommonLyt);
-			this.grpHomeExtra.ForeColor = System.Drawing.Color.White;
-			this.grpHomeExtra.Location = new System.Drawing.Point(5, 209);
-			this.grpHomeExtra.Name = "grpHomeExtra";
-			this.grpHomeExtra.Size = new System.Drawing.Size(630, 70);
-			this.grpHomeExtra.TabIndex = 5;
-			this.grpHomeExtra.TabStop = false;
-			this.grpHomeExtra.Text = "Home menu optional settings";
-			this.grpHomeExtra.Visible = false;
-			// 
-			// btnApplet6
-			// 
-			this.btnApplet6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet6.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet6.Location = new System.Drawing.Point(535, 41);
-			this.btnApplet6.Name = "btnApplet6";
-			this.btnApplet6.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet6.TabIndex = 7;
-			this.btnApplet6.Text = "Power";
-			this.btnApplet6.UseVisualStyleBackColor = true;
-			// 
-			// btnApplet5
-			// 
-			this.btnApplet5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet5.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet5.Location = new System.Drawing.Point(467, 41);
-			this.btnApplet5.Name = "btnApplet5";
-			this.btnApplet5.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet5.TabIndex = 6;
-			this.btnApplet5.Text = "Settings";
-			this.btnApplet5.UseVisualStyleBackColor = true;
-			// 
-			// btnApplet4
-			// 
-			this.btnApplet4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet4.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet4.Location = new System.Drawing.Point(400, 41);
-			this.btnApplet4.Name = "btnApplet4";
-			this.btnApplet4.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet4.TabIndex = 5;
-			this.btnApplet4.Text = "Controller";
-			this.btnApplet4.UseVisualStyleBackColor = true;
-			// 
-			// btnApplet3
-			// 
-			this.btnApplet3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet3.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet3.Location = new System.Drawing.Point(332, 41);
-			this.btnApplet3.Name = "btnApplet3";
-			this.btnApplet3.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet3.TabIndex = 4;
-			this.btnApplet3.Text = "Shop";
-			this.btnApplet3.UseVisualStyleBackColor = true;
-			// 
-			// btnApplet2
-			// 
-			this.btnApplet2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet2.Location = new System.Drawing.Point(264, 41);
-			this.btnApplet2.Name = "btnApplet2";
-			this.btnApplet2.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet2.TabIndex = 3;
-			this.btnApplet2.Text = "News";
-			this.btnApplet2.UseVisualStyleBackColor = true;
-			// 
-			// button1
-			// 
-			this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.button1.Location = new System.Drawing.Point(605, 12);
-			this.button1.Name = "button1";
-			this.button1.Size = new System.Drawing.Size(19, 23);
-			this.button1.TabIndex = 1;
-			this.button1.Text = "?";
-			this.button1.UseVisualStyleBackColor = true;
-			this.button1.Click += new System.EventHandler(this.button1_Click);
-			// 
-			// btnAlbumIcoHelp
-			// 
-			this.btnAlbumIcoHelp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnAlbumIcoHelp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnAlbumIcoHelp.Location = new System.Drawing.Point(605, 41);
-			this.btnAlbumIcoHelp.Name = "btnAlbumIcoHelp";
-			this.btnAlbumIcoHelp.Size = new System.Drawing.Size(19, 23);
-			this.btnAlbumIcoHelp.TabIndex = 8;
-			this.btnAlbumIcoHelp.Text = "?";
-			this.btnAlbumIcoHelp.UseVisualStyleBackColor = true;
-			this.btnAlbumIcoHelp.Click += new System.EventHandler(this.btnAlbumIcoHelp_Click);
-			// 
-			// btnApplet1
-			// 
-			this.btnApplet1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnApplet1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnApplet1.Location = new System.Drawing.Point(195, 41);
-			this.btnApplet1.Name = "btnApplet1";
-			this.btnApplet1.Size = new System.Drawing.Size(64, 23);
-			this.btnApplet1.TabIndex = 2;
-			this.btnApplet1.Text = "Album";
-			this.btnApplet1.UseVisualStyleBackColor = true;
-			// 
-			// lblAppletIcons
-			// 
-			this.lblAppletIcons.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.grpHomeExtra.Controls.Add(this.btnApplet6);
+            this.grpHomeExtra.Controls.Add(this.btnApplet5);
+            this.grpHomeExtra.Controls.Add(this.btnApplet4);
+            this.grpHomeExtra.Controls.Add(this.btnApplet3);
+            this.grpHomeExtra.Controls.Add(this.btnApplet2);
+            this.grpHomeExtra.Controls.Add(this.button1);
+            this.grpHomeExtra.Controls.Add(this.btnAlbumIcoHelp);
+            this.grpHomeExtra.Controls.Add(this.btnApplet1);
+            this.grpHomeExtra.Controls.Add(this.btnApplet7);
+            this.grpHomeExtra.Controls.Add(this.btnApplet8);
+            this.grpHomeExtra.Controls.Add(this.btnApplet9);
+            this.grpHomeExtra.Controls.Add(this.lblAppletIcons);
+            this.grpHomeExtra.Controls.Add(this.btnOpenCustomLayout);
+            this.grpHomeExtra.Controls.Add(this.lblCustomCommonLyt);
+            this.grpHomeExtra.ForeColor = System.Drawing.Color.White;
+            this.grpHomeExtra.Location = new System.Drawing.Point(5, 209);
+            this.grpHomeExtra.Name = "grpHomeExtra";
+            this.grpHomeExtra.Size = new System.Drawing.Size(699, 113);
+            this.grpHomeExtra.TabIndex = 5;
+            this.grpHomeExtra.TabStop = false;
+            this.grpHomeExtra.Text = "Home menu optional settings";
+            this.grpHomeExtra.Visible = false;
+            // 
+            // btnApplet6
+            // 
+            this.btnApplet6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet6.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet6.Location = new System.Drawing.Point(604, 41);
+            this.btnApplet6.Name = "btnApplet6";
+            this.btnApplet6.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet6.TabIndex = 7;
+            this.btnApplet6.Text = "Power";
+            this.btnApplet6.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet5
+            // 
+            this.btnApplet5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet5.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet5.Location = new System.Drawing.Point(536, 41);
+            this.btnApplet5.Name = "btnApplet5";
+            this.btnApplet5.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet5.TabIndex = 6;
+            this.btnApplet5.Text = "Settings";
+            this.btnApplet5.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet4
+            // 
+            this.btnApplet4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet4.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet4.Location = new System.Drawing.Point(469, 41);
+            this.btnApplet4.Name = "btnApplet4";
+            this.btnApplet4.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet4.TabIndex = 5;
+            this.btnApplet4.Text = "Controller";
+            this.btnApplet4.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet3
+            // 
+            this.btnApplet3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet3.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet3.Location = new System.Drawing.Point(401, 41);
+            this.btnApplet3.Name = "btnApplet3";
+            this.btnApplet3.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet3.TabIndex = 4;
+            this.btnApplet3.Text = "Shop";
+            this.btnApplet3.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet2
+            // 
+            this.btnApplet2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet2.Location = new System.Drawing.Point(333, 41);
+            this.btnApplet2.Name = "btnApplet2";
+            this.btnApplet2.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet2.TabIndex = 3;
+            this.btnApplet2.Text = "News";
+            this.btnApplet2.UseVisualStyleBackColor = true;
+            // 
+            // button1
+            // 
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button1.Location = new System.Drawing.Point(674, 12);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(19, 23);
+            this.button1.TabIndex = 1;
+            this.button1.Text = "?";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // btnAlbumIcoHelp
+            // 
+            this.btnAlbumIcoHelp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnAlbumIcoHelp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnAlbumIcoHelp.Location = new System.Drawing.Point(674, 41);
+            this.btnAlbumIcoHelp.Name = "btnAlbumIcoHelp";
+            this.btnAlbumIcoHelp.Size = new System.Drawing.Size(19, 23);
+            this.btnAlbumIcoHelp.TabIndex = 8;
+            this.btnAlbumIcoHelp.Text = "?";
+            this.btnAlbumIcoHelp.UseVisualStyleBackColor = true;
+            this.btnAlbumIcoHelp.Click += new System.EventHandler(this.btnAlbumIcoHelp_Click);
+            // 
+            // btnApplet1
+            // 
+            this.btnApplet1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet1.Location = new System.Drawing.Point(264, 41);
+            this.btnApplet1.Name = "btnApplet1";
+            this.btnApplet1.Size = new System.Drawing.Size(64, 23);
+            this.btnApplet1.TabIndex = 2;
+            this.btnApplet1.Text = "Album";
+            this.btnApplet1.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet7
+            // 
+            this.btnApplet7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet7.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet7.Location = new System.Drawing.Point(183, 41);
+            this.btnApplet7.Name = "btnApplet7";
+            this.btnApplet7.Size = new System.Drawing.Size(75, 23);
+            this.btnApplet7.TabIndex = 9;
+            this.btnApplet7.Text = "NSO";
+            this.btnApplet7.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet8
+            // 
+            this.btnApplet8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet8.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet8.Location = new System.Drawing.Point(183, 71);
+            this.btnApplet8.Name = "btnApplet8";
+            this.btnApplet8.Size = new System.Drawing.Size(75, 23);
+            this.btnApplet8.TabIndex = 10;
+            this.btnApplet8.Text = "Game Card";
+            this.btnApplet8.UseVisualStyleBackColor = true;
+            // 
+            // btnApplet9
+            // 
+            this.btnApplet9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApplet9.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApplet9.Location = new System.Drawing.Point(264, 71);
+            this.btnApplet9.Name = "btnApplet9";
+            this.btnApplet9.Size = new System.Drawing.Size(85, 23);
+            this.btnApplet9.TabIndex = 11;
+            this.btnApplet9.Text = "Game Share";
+            this.btnApplet9.UseVisualStyleBackColor = true;
+            // 
+            // lblAppletIcons
+            // 
+            this.lblAppletIcons.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblAppletIcons.Depth = 0;
-			this.lblAppletIcons.Font = new System.Drawing.Font("Roboto", 11F);
-			this.lblAppletIcons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.lblAppletIcons.Location = new System.Drawing.Point(6, 43);
-			this.lblAppletIcons.MouseState = MaterialSkin.MouseState.HOVER;
-			this.lblAppletIcons.Name = "lblAppletIcons";
-			this.lblAppletIcons.Size = new System.Drawing.Size(163, 19);
-			this.lblAppletIcons.TabIndex = 15;
-			this.lblAppletIcons.Text = "Custom applet icons:";
-			// 
-			// btnOpenCustomLayout
-			// 
-			this.btnOpenCustomLayout.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnOpenCustomLayout.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnOpenCustomLayout.Location = new System.Drawing.Point(566, 12);
-			this.btnOpenCustomLayout.Name = "btnOpenCustomLayout";
-			this.btnOpenCustomLayout.Size = new System.Drawing.Size(33, 23);
-			this.btnOpenCustomLayout.TabIndex = 0;
-			this.btnOpenCustomLayout.Text = "...";
-			this.btnOpenCustomLayout.UseVisualStyleBackColor = true;
-			this.btnOpenCustomLayout.Click += new System.EventHandler(this.btnOpenCustomLayout_Click);
-			// 
-			// lblCustomCommonLyt
-			// 
-			this.lblCustomCommonLyt.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lblAppletIcons.Depth = 0;
+            this.lblAppletIcons.Font = new System.Drawing.Font("Roboto", 11F);
+            this.lblAppletIcons.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblAppletIcons.Location = new System.Drawing.Point(6, 43);
+            this.lblAppletIcons.MouseState = MaterialSkin.MouseState.HOVER;
+            this.lblAppletIcons.Name = "lblAppletIcons";
+            this.lblAppletIcons.Size = new System.Drawing.Size(232, 19);
+            this.lblAppletIcons.TabIndex = 15;
+            this.lblAppletIcons.Text = "Custom applet icons:";
+            // 
+            // btnOpenCustomLayout
+            // 
+            this.btnOpenCustomLayout.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOpenCustomLayout.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOpenCustomLayout.Location = new System.Drawing.Point(635, 12);
+            this.btnOpenCustomLayout.Name = "btnOpenCustomLayout";
+            this.btnOpenCustomLayout.Size = new System.Drawing.Size(33, 23);
+            this.btnOpenCustomLayout.TabIndex = 0;
+            this.btnOpenCustomLayout.Text = "...";
+            this.btnOpenCustomLayout.UseVisualStyleBackColor = true;
+            this.btnOpenCustomLayout.Click += new System.EventHandler(this.btnOpenCustomLayout_Click);
+            // 
+            // lblCustomCommonLyt
+            // 
+            this.lblCustomCommonLyt.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblCustomCommonLyt.Depth = 0;
-			this.lblCustomCommonLyt.Font = new System.Drawing.Font("Roboto", 11F);
-			this.lblCustomCommonLyt.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.lblCustomCommonLyt.Location = new System.Drawing.Point(6, 16);
-			this.lblCustomCommonLyt.MouseState = MaterialSkin.MouseState.HOVER;
-			this.lblCustomCommonLyt.Name = "lblCustomCommonLyt";
-			this.lblCustomCommonLyt.Size = new System.Drawing.Size(554, 19);
-			this.lblCustomCommonLyt.TabIndex = 12;
-			this.lblCustomCommonLyt.Text = "Custom common layout: Not set";
-			// 
-			// grpLockExtra
-			// 
-			this.grpLockExtra.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.lblCustomCommonLyt.Depth = 0;
+            this.lblCustomCommonLyt.Font = new System.Drawing.Font("Roboto", 11F);
+            this.lblCustomCommonLyt.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblCustomCommonLyt.Location = new System.Drawing.Point(6, 16);
+            this.lblCustomCommonLyt.MouseState = MaterialSkin.MouseState.HOVER;
+            this.lblCustomCommonLyt.Name = "lblCustomCommonLyt";
+            this.lblCustomCommonLyt.Size = new System.Drawing.Size(623, 19);
+            this.lblCustomCommonLyt.TabIndex = 12;
+            this.lblCustomCommonLyt.Text = "Custom common layout: Not set";
+            // 
+            // grpLockExtra
+            // 
+            this.grpLockExtra.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpLockExtra.Controls.Add(this.button7);
-			this.grpLockExtra.Controls.Add(this.btnCustomLock);
-			this.grpLockExtra.Controls.Add(this.lblCustomLock);
-			this.grpLockExtra.ForeColor = System.Drawing.Color.White;
-			this.grpLockExtra.Location = new System.Drawing.Point(5, 209);
-			this.grpLockExtra.Name = "grpLockExtra";
-			this.grpLockExtra.Size = new System.Drawing.Size(630, 70);
-			this.grpLockExtra.TabIndex = 26;
-			this.grpLockExtra.TabStop = false;
-			this.grpLockExtra.Text = "Lock screen optional settings";
-			this.grpLockExtra.Visible = false;
-			// 
-			// button7
-			// 
-			this.button7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.button7.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.button7.Location = new System.Drawing.Point(604, 12);
-			this.button7.Name = "button7";
-			this.button7.Size = new System.Drawing.Size(19, 23);
-			this.button7.TabIndex = 18;
-			this.button7.Text = "?";
-			this.button7.UseVisualStyleBackColor = true;
-			this.button7.Click += new System.EventHandler(this.Button7_Click);
-			// 
-			// btnCustomLock
-			// 
-			this.btnCustomLock.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnCustomLock.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnCustomLock.Location = new System.Drawing.Point(566, 12);
-			this.btnCustomLock.Name = "btnCustomLock";
-			this.btnCustomLock.Size = new System.Drawing.Size(33, 23);
-			this.btnCustomLock.TabIndex = 14;
-			this.btnCustomLock.Text = "...";
-			this.btnCustomLock.UseVisualStyleBackColor = true;
-			this.btnCustomLock.Click += new System.EventHandler(this.BtnCustomLock_Click);
-			// 
-			// lblCustomLock
-			// 
-			this.lblCustomLock.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.grpLockExtra.Controls.Add(this.button7);
+            this.grpLockExtra.Controls.Add(this.btnCustomLock);
+            this.grpLockExtra.Controls.Add(this.lblCustomLock);
+            this.grpLockExtra.ForeColor = System.Drawing.Color.White;
+            this.grpLockExtra.Location = new System.Drawing.Point(5, 209);
+            this.grpLockExtra.Name = "grpLockExtra";
+            this.grpLockExtra.Size = new System.Drawing.Size(699, 113);
+            this.grpLockExtra.TabIndex = 26;
+            this.grpLockExtra.TabStop = false;
+            this.grpLockExtra.Text = "Lock screen optional settings";
+            this.grpLockExtra.Visible = false;
+            // 
+            // button7
+            // 
+            this.button7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button7.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button7.Location = new System.Drawing.Point(673, 12);
+            this.button7.Name = "button7";
+            this.button7.Size = new System.Drawing.Size(19, 23);
+            this.button7.TabIndex = 18;
+            this.button7.Text = "?";
+            this.button7.UseVisualStyleBackColor = true;
+            this.button7.Click += new System.EventHandler(this.Button7_Click);
+            // 
+            // btnCustomLock
+            // 
+            this.btnCustomLock.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCustomLock.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCustomLock.Location = new System.Drawing.Point(635, 12);
+            this.btnCustomLock.Name = "btnCustomLock";
+            this.btnCustomLock.Size = new System.Drawing.Size(33, 23);
+            this.btnCustomLock.TabIndex = 14;
+            this.btnCustomLock.Text = "...";
+            this.btnCustomLock.UseVisualStyleBackColor = true;
+            this.btnCustomLock.Click += new System.EventHandler(this.BtnCustomLock_Click);
+            // 
+            // lblCustomLock
+            // 
+            this.lblCustomLock.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblCustomLock.Depth = 0;
-			this.lblCustomLock.Font = new System.Drawing.Font("Roboto", 11F);
-			this.lblCustomLock.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.lblCustomLock.Location = new System.Drawing.Point(6, 16);
-			this.lblCustomLock.MouseState = MaterialSkin.MouseState.HOVER;
-			this.lblCustomLock.Name = "lblCustomLock";
-			this.lblCustomLock.Size = new System.Drawing.Size(554, 19);
-			this.lblCustomLock.TabIndex = 12;
-			this.lblCustomLock.Text = "Custom home icon: Not set";
-			// 
-			// ExtractPage
-			// 
-			this.ExtractPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.ExtractPage.Controls.Add(this.materialLabel18);
-			this.ExtractPage.Controls.Add(this.ExtractNxthemeBtn);
-			this.ExtractPage.Controls.Add(this.materialLabel14);
-			this.ExtractPage.Location = new System.Drawing.Point(4, 22);
-			this.ExtractPage.Name = "ExtractPage";
-			this.ExtractPage.Padding = new System.Windows.Forms.Padding(3);
-			this.ExtractPage.Size = new System.Drawing.Size(638, 331);
-			this.ExtractPage.TabIndex = 5;
-			this.ExtractPage.Text = "Extract nxtheme";
-			// 
-			// materialLabel18
-			// 
-			this.materialLabel18.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lblCustomLock.Depth = 0;
+            this.lblCustomLock.Font = new System.Drawing.Font("Roboto", 11F);
+            this.lblCustomLock.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblCustomLock.Location = new System.Drawing.Point(6, 16);
+            this.lblCustomLock.MouseState = MaterialSkin.MouseState.HOVER;
+            this.lblCustomLock.Name = "lblCustomLock";
+            this.lblCustomLock.Size = new System.Drawing.Size(623, 19);
+            this.lblCustomLock.TabIndex = 12;
+            this.lblCustomLock.Text = "Custom home icon: Not set";
+            // 
+            // ExtractPage
+            // 
+            this.ExtractPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.ExtractPage.Controls.Add(this.materialLabel18);
+            this.ExtractPage.Controls.Add(this.ExtractNxthemeBtn);
+            this.ExtractPage.Controls.Add(this.materialLabel14);
+            this.ExtractPage.Location = new System.Drawing.Point(4, 22);
+            this.ExtractPage.Name = "ExtractPage";
+            this.ExtractPage.Padding = new System.Windows.Forms.Padding(3);
+            this.ExtractPage.Size = new System.Drawing.Size(638, 331);
+            this.ExtractPage.TabIndex = 5;
+            this.ExtractPage.Text = "Extract nxtheme";
+            // 
+            // materialLabel18
+            // 
+            this.materialLabel18.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel18.Depth = 0;
-			this.materialLabel18.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel18.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel18.Location = new System.Drawing.Point(3, 84);
-			this.materialLabel18.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel18.Name = "materialLabel18";
-			this.materialLabel18.Size = new System.Drawing.Size(633, 25);
-			this.materialLabel18.TabIndex = 13;
-			this.materialLabel18.Text = "Once the files have been extracted you can create a new theme in the \"NXTHEME BUI" +
+            this.materialLabel18.Depth = 0;
+            this.materialLabel18.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel18.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel18.Location = new System.Drawing.Point(3, 84);
+            this.materialLabel18.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel18.Name = "materialLabel18";
+            this.materialLabel18.Size = new System.Drawing.Size(633, 25);
+            this.materialLabel18.TabIndex = 13;
+            this.materialLabel18.Text = "Once the files have been extracted you can create a new theme in the \"NXTHEME BUI" +
     "LDER\" tab";
-			this.materialLabel18.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// ExtractNxthemeBtn
-			// 
-			this.ExtractNxthemeBtn.AllowDrop = true;
-			this.ExtractNxthemeBtn.Anchor = System.Windows.Forms.AnchorStyles.Top;
-			this.ExtractNxthemeBtn.AutoSize = true;
-			this.ExtractNxthemeBtn.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.ExtractNxthemeBtn.Depth = 0;
-			this.ExtractNxthemeBtn.Icon = null;
-			this.ExtractNxthemeBtn.Location = new System.Drawing.Point(254, 40);
-			this.ExtractNxthemeBtn.MouseState = MaterialSkin.MouseState.HOVER;
-			this.ExtractNxthemeBtn.Name = "ExtractNxthemeBtn";
-			this.ExtractNxthemeBtn.Primary = true;
-			this.ExtractNxthemeBtn.Size = new System.Drawing.Size(124, 36);
-			this.ExtractNxthemeBtn.TabIndex = 0;
-			this.ExtractNxthemeBtn.Text = "Open nxtheme";
-			this.ExtractNxthemeBtn.UseVisualStyleBackColor = true;
-			this.ExtractNxthemeBtn.Click += new System.EventHandler(this.ExtractNxTheme_Click);
-			this.ExtractNxthemeBtn.DragDrop += new System.Windows.Forms.DragEventHandler(this.ExtractNxthemeBtn_DragDrop);
-			this.ExtractNxthemeBtn.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel14
-			// 
-			this.materialLabel14.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel18.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // ExtractNxthemeBtn
+            // 
+            this.ExtractNxthemeBtn.AllowDrop = true;
+            this.ExtractNxthemeBtn.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.ExtractNxthemeBtn.AutoSize = true;
+            this.ExtractNxthemeBtn.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ExtractNxthemeBtn.Depth = 0;
+            this.ExtractNxthemeBtn.Icon = null;
+            this.ExtractNxthemeBtn.Location = new System.Drawing.Point(254, 40);
+            this.ExtractNxthemeBtn.MouseState = MaterialSkin.MouseState.HOVER;
+            this.ExtractNxthemeBtn.Name = "ExtractNxthemeBtn";
+            this.ExtractNxthemeBtn.Primary = true;
+            this.ExtractNxthemeBtn.Size = new System.Drawing.Size(124, 36);
+            this.ExtractNxthemeBtn.TabIndex = 0;
+            this.ExtractNxthemeBtn.Text = "Open nxtheme";
+            this.ExtractNxthemeBtn.UseVisualStyleBackColor = true;
+            this.ExtractNxthemeBtn.Click += new System.EventHandler(this.ExtractNxTheme_Click);
+            this.ExtractNxthemeBtn.DragDrop += new System.Windows.Forms.DragEventHandler(this.ExtractNxthemeBtn_DragDrop);
+            this.ExtractNxthemeBtn.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel14
+            // 
+            this.materialLabel14.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel14.Depth = 0;
-			this.materialLabel14.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel14.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel14.Location = new System.Drawing.Point(3, 8);
-			this.materialLabel14.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel14.Name = "materialLabel14";
-			this.materialLabel14.Size = new System.Drawing.Size(633, 25);
-			this.materialLabel14.TabIndex = 8;
-			this.materialLabel14.Text = "In this page you can extract an nxtheme file to edit its assets";
-			this.materialLabel14.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// InfoPage
-			// 
-			this.InfoPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.InfoPage.Controls.Add(this.materialLabel13);
-			this.InfoPage.Controls.Add(this.SubredditLinkLbl);
-			this.InfoPage.Controls.Add(this.QceanLinkLbl);
-			this.InfoPage.Controls.Add(this.DiscordLinkLbl);
-			this.InfoPage.Controls.Add(this.SupportLinkLbl);
-			this.InfoPage.Controls.Add(this.GithubLinkLbl);
-			this.InfoPage.Controls.Add(this.materialLabel10);
-			this.InfoPage.Controls.Add(this.tbPatches);
-			this.InfoPage.Location = new System.Drawing.Point(4, 22);
-			this.InfoPage.Name = "InfoPage";
-			this.InfoPage.Size = new System.Drawing.Size(638, 331);
-			this.InfoPage.TabIndex = 2;
-			this.InfoPage.Text = "Help&Info";
-			// 
-			// materialLabel13
-			// 
-			this.materialLabel13.Depth = 0;
-			this.materialLabel13.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel13.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel13.Location = new System.Drawing.Point(8, 67);
-			this.materialLabel13.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel13.Name = "materialLabel13";
-			this.materialLabel13.Size = new System.Drawing.Size(296, 25);
-			this.materialLabel13.TabIndex = 22;
-			this.materialLabel13.Text = "Finding new themes or posting your own :";
-			this.materialLabel13.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// SubredditLinkLbl
-			// 
-			this.SubredditLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.SubredditLinkLbl.LinkColor = System.Drawing.Color.Red;
-			this.SubredditLinkLbl.Location = new System.Drawing.Point(308, 70);
-			this.SubredditLinkLbl.Name = "SubredditLinkLbl";
-			this.SubredditLinkLbl.Size = new System.Drawing.Size(147, 21);
-			this.SubredditLinkLbl.TabIndex = 21;
-			this.SubredditLinkLbl.TabStop = true;
-			this.SubredditLinkLbl.Text = "r/NXThemes subreddit";
-			this.SubredditLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.SubredditLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SubredditLinkLbl_LinkClicked);
-			// 
-			// QceanLinkLbl
-			// 
-			this.QceanLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.QceanLinkLbl.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
-			this.QceanLinkLbl.Location = new System.Drawing.Point(482, 70);
-			this.QceanLinkLbl.Name = "QceanLinkLbl";
-			this.QceanLinkLbl.Size = new System.Drawing.Size(147, 21);
-			this.QceanLinkLbl.TabIndex = 20;
-			this.QceanLinkLbl.TabStop = true;
-			this.QceanLinkLbl.Text = "Qcean discord";
-			this.QceanLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.QceanLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.QceanLinkLbl_LinkClicked);
-			// 
-			// DiscordLinkLbl
-			// 
-			this.DiscordLinkLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel14.Depth = 0;
+            this.materialLabel14.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel14.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel14.Location = new System.Drawing.Point(3, 8);
+            this.materialLabel14.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel14.Name = "materialLabel14";
+            this.materialLabel14.Size = new System.Drawing.Size(633, 25);
+            this.materialLabel14.TabIndex = 8;
+            this.materialLabel14.Text = "In this page you can extract an nxtheme file to edit its assets";
+            this.materialLabel14.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // InfoPage
+            // 
+            this.InfoPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.InfoPage.Controls.Add(this.materialLabel13);
+            this.InfoPage.Controls.Add(this.SubredditLinkLbl);
+            this.InfoPage.Controls.Add(this.QceanLinkLbl);
+            this.InfoPage.Controls.Add(this.DiscordLinkLbl);
+            this.InfoPage.Controls.Add(this.SupportLinkLbl);
+            this.InfoPage.Controls.Add(this.GithubLinkLbl);
+            this.InfoPage.Controls.Add(this.materialLabel10);
+            this.InfoPage.Controls.Add(this.tbPatches);
+            this.InfoPage.Location = new System.Drawing.Point(4, 22);
+            this.InfoPage.Name = "InfoPage";
+            this.InfoPage.Size = new System.Drawing.Size(638, 331);
+            this.InfoPage.TabIndex = 2;
+            this.InfoPage.Text = "Help&Info";
+            // 
+            // materialLabel13
+            // 
+            this.materialLabel13.Depth = 0;
+            this.materialLabel13.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel13.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel13.Location = new System.Drawing.Point(8, 67);
+            this.materialLabel13.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel13.Name = "materialLabel13";
+            this.materialLabel13.Size = new System.Drawing.Size(296, 25);
+            this.materialLabel13.TabIndex = 22;
+            this.materialLabel13.Text = "Finding new themes or posting your own :";
+            this.materialLabel13.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // SubredditLinkLbl
+            // 
+            this.SubredditLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.SubredditLinkLbl.LinkColor = System.Drawing.Color.Red;
+            this.SubredditLinkLbl.Location = new System.Drawing.Point(308, 70);
+            this.SubredditLinkLbl.Name = "SubredditLinkLbl";
+            this.SubredditLinkLbl.Size = new System.Drawing.Size(147, 21);
+            this.SubredditLinkLbl.TabIndex = 21;
+            this.SubredditLinkLbl.TabStop = true;
+            this.SubredditLinkLbl.Text = "r/NXThemes subreddit";
+            this.SubredditLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.SubredditLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SubredditLinkLbl_LinkClicked);
+            // 
+            // QceanLinkLbl
+            // 
+            this.QceanLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.QceanLinkLbl.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+            this.QceanLinkLbl.Location = new System.Drawing.Point(482, 70);
+            this.QceanLinkLbl.Name = "QceanLinkLbl";
+            this.QceanLinkLbl.Size = new System.Drawing.Size(147, 21);
+            this.QceanLinkLbl.TabIndex = 20;
+            this.QceanLinkLbl.TabStop = true;
+            this.QceanLinkLbl.Text = "Qcean discord";
+            this.QceanLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.QceanLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.QceanLinkLbl_LinkClicked);
+            // 
+            // DiscordLinkLbl
+            // 
+            this.DiscordLinkLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.DiscordLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.DiscordLinkLbl.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
-			this.DiscordLinkLbl.Location = new System.Drawing.Point(271, 38);
-			this.DiscordLinkLbl.Name = "DiscordLinkLbl";
-			this.DiscordLinkLbl.Size = new System.Drawing.Size(147, 21);
-			this.DiscordLinkLbl.TabIndex = 18;
-			this.DiscordLinkLbl.TabStop = true;
-			this.DiscordLinkLbl.Text = "Exelix\'s discord server";
-			this.DiscordLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.DiscordLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.DiscordLinkLbl_LinkClicked);
-			// 
-			// SupportLinkLbl
-			// 
-			this.SupportLinkLbl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.SupportLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.SupportLinkLbl.LinkColor = System.Drawing.Color.DarkOrange;
-			this.SupportLinkLbl.Location = new System.Drawing.Point(458, 38);
-			this.SupportLinkLbl.Name = "SupportLinkLbl";
-			this.SupportLinkLbl.Size = new System.Drawing.Size(174, 21);
-			this.SupportLinkLbl.TabIndex = 17;
-			this.SupportLinkLbl.TabStop = true;
-			this.SupportLinkLbl.Text = "Donate ❤";
-			this.SupportLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.SupportLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SupportLinkLbl_LinkClicked);
-			// 
-			// GithubLinkLbl
-			// 
-			this.GithubLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.GithubLinkLbl.LinkColor = System.Drawing.Color.Aqua;
-			this.GithubLinkLbl.Location = new System.Drawing.Point(9, 38);
-			this.GithubLinkLbl.Name = "GithubLinkLbl";
-			this.GithubLinkLbl.Size = new System.Drawing.Size(199, 21);
-			this.GithubLinkLbl.TabIndex = 16;
-			this.GithubLinkLbl.TabStop = true;
-			this.GithubLinkLbl.Text = "Updates on GitHub";
-			this.GithubLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.GithubLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.GithubLinkLbl_LinkClicked);
-			// 
-			// materialLabel10
-			// 
-			this.materialLabel10.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.DiscordLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.DiscordLinkLbl.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+            this.DiscordLinkLbl.Location = new System.Drawing.Point(271, 38);
+            this.DiscordLinkLbl.Name = "DiscordLinkLbl";
+            this.DiscordLinkLbl.Size = new System.Drawing.Size(147, 21);
+            this.DiscordLinkLbl.TabIndex = 18;
+            this.DiscordLinkLbl.TabStop = true;
+            this.DiscordLinkLbl.Text = "Exelix\'s discord server";
+            this.DiscordLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.DiscordLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.DiscordLinkLbl_LinkClicked);
+            // 
+            // SupportLinkLbl
+            // 
+            this.SupportLinkLbl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.SupportLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.SupportLinkLbl.LinkColor = System.Drawing.Color.DarkOrange;
+            this.SupportLinkLbl.Location = new System.Drawing.Point(458, 38);
+            this.SupportLinkLbl.Name = "SupportLinkLbl";
+            this.SupportLinkLbl.Size = new System.Drawing.Size(174, 21);
+            this.SupportLinkLbl.TabIndex = 17;
+            this.SupportLinkLbl.TabStop = true;
+            this.SupportLinkLbl.Text = "Donate ❤";
+            this.SupportLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.SupportLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SupportLinkLbl_LinkClicked);
+            // 
+            // GithubLinkLbl
+            // 
+            this.GithubLinkLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.GithubLinkLbl.LinkColor = System.Drawing.Color.Aqua;
+            this.GithubLinkLbl.Location = new System.Drawing.Point(9, 38);
+            this.GithubLinkLbl.Name = "GithubLinkLbl";
+            this.GithubLinkLbl.Size = new System.Drawing.Size(199, 21);
+            this.GithubLinkLbl.TabIndex = 16;
+            this.GithubLinkLbl.TabStop = true;
+            this.GithubLinkLbl.Text = "Updates on GitHub";
+            this.GithubLinkLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.GithubLinkLbl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.GithubLinkLbl_LinkClicked);
+            // 
+            // materialLabel10
+            // 
+            this.materialLabel10.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel10.Depth = 0;
-			this.materialLabel10.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel10.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel10.Location = new System.Drawing.Point(2, 2);
-			this.materialLabel10.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel10.Name = "materialLabel10";
-			this.materialLabel10.Size = new System.Drawing.Size(633, 41);
-			this.materialLabel10.TabIndex = 13;
-			this.materialLabel10.Text = "Switch theme injector Ver. X.Y.Z By exelix";
-			this.materialLabel10.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.materialLabel10.Click += new System.EventHandler(this.materialLabel10_Click);
-			// 
-			// tbPatches
-			// 
-			this.tbPatches.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.materialLabel10.Depth = 0;
+            this.materialLabel10.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel10.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel10.Location = new System.Drawing.Point(2, 2);
+            this.materialLabel10.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel10.Name = "materialLabel10";
+            this.materialLabel10.Size = new System.Drawing.Size(633, 41);
+            this.materialLabel10.TabIndex = 13;
+            this.materialLabel10.Text = "Switch theme injector Ver. X.Y.Z By exelix";
+            this.materialLabel10.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.materialLabel10.Click += new System.EventHandler(this.materialLabel10_Click);
+            // 
+            // tbPatches
+            // 
+            this.tbPatches.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbPatches.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.tbPatches.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.tbPatches.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.tbPatches.ForeColor = System.Drawing.Color.White;
-			this.tbPatches.Location = new System.Drawing.Point(3, 110);
-			this.tbPatches.Multiline = true;
-			this.tbPatches.Name = "tbPatches";
-			this.tbPatches.ReadOnly = true;
-			this.tbPatches.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-			this.tbPatches.Size = new System.Drawing.Size(635, 218);
-			this.tbPatches.TabIndex = 12;
-			this.tbPatches.Text = resources.GetString("tbPatches.Text");
-			// 
-			// InjectPage
-			// 
-			this.InjectPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.InjectPage.Controls.Add(this.lblDetected);
-			this.InjectPage.Controls.Add(this.materialRaisedButton3);
-			this.InjectPage.Controls.Add(this.tbImageFile);
-			this.InjectPage.Controls.Add(this.materialLabel7);
-			this.InjectPage.Controls.Add(this.linkLabel1);
-			this.InjectPage.Controls.Add(this.LayoutPatchList);
-			this.InjectPage.Controls.Add(this.materialLabel6);
-			this.InjectPage.Controls.Add(this.materialFlatButton1);
-			this.InjectPage.Controls.Add(this.materialLabel2);
-			this.InjectPage.Controls.Add(this.materialRaisedButton2);
-			this.InjectPage.Controls.Add(this.materialLabel3);
-			this.InjectPage.Controls.Add(this.materialLabel17);
-			this.InjectPage.Controls.Add(this.materialLabel1);
-			this.InjectPage.Location = new System.Drawing.Point(4, 22);
-			this.InjectPage.Name = "InjectPage";
-			this.InjectPage.Padding = new System.Windows.Forms.Padding(3);
-			this.InjectPage.Size = new System.Drawing.Size(638, 331);
-			this.InjectPage.TabIndex = 1;
-			this.InjectPage.Text = "SZS";
-			// 
-			// lblDetected
-			// 
-			this.lblDetected.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblDetected.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.lblDetected.Depth = 0;
-			this.lblDetected.Font = new System.Drawing.Font("Roboto", 11F);
-			this.lblDetected.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.lblDetected.Location = new System.Drawing.Point(366, 59);
-			this.lblDetected.MouseState = MaterialSkin.MouseState.HOVER;
-			this.lblDetected.Name = "lblDetected";
-			this.lblDetected.Size = new System.Drawing.Size(260, 22);
-			this.lblDetected.TabIndex = 13;
-			this.lblDetected.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.lblDetected.MouseDown += new System.Windows.Forms.MouseEventHandler(this.DragForm_MouseDown);
-			// 
-			// materialRaisedButton3
-			// 
-			this.materialRaisedButton3.Anchor = System.Windows.Forms.AnchorStyles.Top;
-			this.materialRaisedButton3.AutoSize = true;
-			this.materialRaisedButton3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton3.Depth = 0;
-			this.materialRaisedButton3.Icon = null;
-			this.materialRaisedButton3.Location = new System.Drawing.Point(274, 52);
-			this.materialRaisedButton3.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton3.Name = "materialRaisedButton3";
-			this.materialRaisedButton3.Primary = true;
-			this.materialRaisedButton3.Size = new System.Drawing.Size(85, 36);
-			this.materialRaisedButton3.TabIndex = 0;
-			this.materialRaisedButton3.Text = "Open SZS";
-			this.materialRaisedButton3.UseVisualStyleBackColor = true;
-			this.materialRaisedButton3.Click += new System.EventHandler(this.OpenSzsButton);
-			// 
-			// tbImageFile
-			// 
-			this.tbImageFile.AllowDrop = true;
-			this.tbImageFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbPatches.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.tbPatches.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tbPatches.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tbPatches.ForeColor = System.Drawing.Color.White;
+            this.tbPatches.Location = new System.Drawing.Point(3, 110);
+            this.tbPatches.Multiline = true;
+            this.tbPatches.Name = "tbPatches";
+            this.tbPatches.ReadOnly = true;
+            this.tbPatches.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.tbPatches.Size = new System.Drawing.Size(635, 218);
+            this.tbPatches.TabIndex = 12;
+            this.tbPatches.Text = resources.GetString("tbPatches.Text");
+            // 
+            // InjectPage
+            // 
+            this.InjectPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.InjectPage.Controls.Add(this.lblDetected);
+            this.InjectPage.Controls.Add(this.materialRaisedButton3);
+            this.InjectPage.Controls.Add(this.tbImageFile);
+            this.InjectPage.Controls.Add(this.materialLabel7);
+            this.InjectPage.Controls.Add(this.linkLabel1);
+            this.InjectPage.Controls.Add(this.LayoutPatchList);
+            this.InjectPage.Controls.Add(this.materialLabel6);
+            this.InjectPage.Controls.Add(this.materialFlatButton1);
+            this.InjectPage.Controls.Add(this.materialLabel2);
+            this.InjectPage.Controls.Add(this.materialRaisedButton2);
+            this.InjectPage.Controls.Add(this.materialLabel3);
+            this.InjectPage.Controls.Add(this.materialLabel17);
+            this.InjectPage.Controls.Add(this.materialLabel1);
+            this.InjectPage.Location = new System.Drawing.Point(4, 22);
+            this.InjectPage.Name = "InjectPage";
+            this.InjectPage.Padding = new System.Windows.Forms.Padding(3);
+            this.InjectPage.Size = new System.Drawing.Size(638, 331);
+            this.InjectPage.TabIndex = 1;
+            this.InjectPage.Text = "SZS";
+            // 
+            // lblDetected
+            // 
+            this.lblDetected.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblDetected.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.lblDetected.Depth = 0;
+            this.lblDetected.Font = new System.Drawing.Font("Roboto", 11F);
+            this.lblDetected.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblDetected.Location = new System.Drawing.Point(366, 59);
+            this.lblDetected.MouseState = MaterialSkin.MouseState.HOVER;
+            this.lblDetected.Name = "lblDetected";
+            this.lblDetected.Size = new System.Drawing.Size(260, 22);
+            this.lblDetected.TabIndex = 13;
+            this.lblDetected.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblDetected.MouseDown += new System.Windows.Forms.MouseEventHandler(this.DragForm_MouseDown);
+            // 
+            // materialRaisedButton3
+            // 
+            this.materialRaisedButton3.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.materialRaisedButton3.AutoSize = true;
+            this.materialRaisedButton3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton3.Depth = 0;
+            this.materialRaisedButton3.Icon = null;
+            this.materialRaisedButton3.Location = new System.Drawing.Point(274, 52);
+            this.materialRaisedButton3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton3.Name = "materialRaisedButton3";
+            this.materialRaisedButton3.Primary = true;
+            this.materialRaisedButton3.Size = new System.Drawing.Size(85, 36);
+            this.materialRaisedButton3.TabIndex = 0;
+            this.materialRaisedButton3.Text = "Open SZS";
+            this.materialRaisedButton3.UseVisualStyleBackColor = true;
+            this.materialRaisedButton3.Click += new System.EventHandler(this.OpenSzsButton);
+            // 
+            // tbImageFile
+            // 
+            this.tbImageFile.AllowDrop = true;
+            this.tbImageFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbImageFile.Location = new System.Drawing.Point(65, 98);
-			this.tbImageFile.Name = "tbImageFile";
-			this.tbImageFile.ReadOnly = true;
-			this.tbImageFile.Size = new System.Drawing.Size(530, 20);
-			this.tbImageFile.TabIndex = 1;
-			this.tbImageFile.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
-			this.tbImageFile.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel7
-			// 
-			this.materialLabel7.Depth = 0;
-			this.materialLabel7.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel7.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel7.Location = new System.Drawing.Point(6, 185);
-			this.materialLabel7.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel7.Name = "materialLabel7";
-			this.materialLabel7.Size = new System.Drawing.Size(620, 64);
-			this.materialLabel7.TabIndex = 10;
-			this.materialLabel7.Text = resources.GetString("materialLabel7.Text");
-			// 
-			// linkLabel1
-			// 
-			this.linkLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.linkLabel1.LinkColor = System.Drawing.SystemColors.MenuHighlight;
-			this.linkLabel1.Location = new System.Drawing.Point(547, 153);
-			this.linkLabel1.Name = "linkLabel1";
-			this.linkLabel1.Size = new System.Drawing.Size(84, 21);
-			this.linkLabel1.TabIndex = 4;
-			this.linkLabel1.TabStop = true;
-			this.linkLabel1.Text = "Preview layout";
-			this.linkLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
-			// 
-			// LayoutPatchList
-			// 
-			this.LayoutPatchList.AllowDrop = true;
-			this.LayoutPatchList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbImageFile.Location = new System.Drawing.Point(65, 98);
+            this.tbImageFile.Name = "tbImageFile";
+            this.tbImageFile.ReadOnly = true;
+            this.tbImageFile.Size = new System.Drawing.Size(530, 20);
+            this.tbImageFile.TabIndex = 1;
+            this.tbImageFile.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
+            this.tbImageFile.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel7
+            // 
+            this.materialLabel7.Depth = 0;
+            this.materialLabel7.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel7.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel7.Location = new System.Drawing.Point(6, 185);
+            this.materialLabel7.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel7.Name = "materialLabel7";
+            this.materialLabel7.Size = new System.Drawing.Size(620, 64);
+            this.materialLabel7.TabIndex = 10;
+            this.materialLabel7.Text = resources.GetString("materialLabel7.Text");
+            // 
+            // linkLabel1
+            // 
+            this.linkLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.linkLabel1.LinkColor = System.Drawing.SystemColors.MenuHighlight;
+            this.linkLabel1.Location = new System.Drawing.Point(547, 153);
+            this.linkLabel1.Name = "linkLabel1";
+            this.linkLabel1.Size = new System.Drawing.Size(84, 21);
+            this.linkLabel1.TabIndex = 4;
+            this.linkLabel1.TabStop = true;
+            this.linkLabel1.Text = "Preview layout";
+            this.linkLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
+            // 
+            // LayoutPatchList
+            // 
+            this.LayoutPatchList.AllowDrop = true;
+            this.LayoutPatchList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.LayoutPatchList.BackColor = System.Drawing.Color.White;
-			this.LayoutPatchList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.LayoutPatchList.FormattingEnabled = true;
-			this.LayoutPatchList.Location = new System.Drawing.Point(108, 153);
-			this.LayoutPatchList.Name = "LayoutPatchList";
-			this.LayoutPatchList.Size = new System.Drawing.Size(433, 21);
-			this.LayoutPatchList.TabIndex = 3;
-			this.LayoutPatchList.SelectedIndexChanged += new System.EventHandler(this.LayoutPatchList_SelectedIndexChanged);
-			this.LayoutPatchList.DragDrop += new System.Windows.Forms.DragEventHandler(this.LayoutPatchList_DragDrop);
-			this.LayoutPatchList.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel6
-			// 
-			this.materialLabel6.Depth = 0;
-			this.materialLabel6.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel6.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel6.Location = new System.Drawing.Point(6, 153);
-			this.materialLabel6.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel6.Name = "materialLabel6";
-			this.materialLabel6.Size = new System.Drawing.Size(103, 19);
-			this.materialLabel6.TabIndex = 7;
-			this.materialLabel6.Text = "Layout patch: ";
-			// 
-			// materialFlatButton1
-			// 
-			this.materialFlatButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialFlatButton1.AutoSize = true;
-			this.materialFlatButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialFlatButton1.Depth = 0;
-			this.materialFlatButton1.ForeColor = System.Drawing.Color.White;
-			this.materialFlatButton1.Icon = null;
-			this.materialFlatButton1.Location = new System.Drawing.Point(602, 90);
-			this.materialFlatButton1.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-			this.materialFlatButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialFlatButton1.Name = "materialFlatButton1";
-			this.materialFlatButton1.Primary = false;
-			this.materialFlatButton1.Size = new System.Drawing.Size(32, 36);
-			this.materialFlatButton1.TabIndex = 2;
-			this.materialFlatButton1.Text = "...";
-			this.materialFlatButton1.UseVisualStyleBackColor = true;
-			this.materialFlatButton1.Click += new System.EventHandler(this.BgImageSelectBtn_Click);
-			this.materialFlatButton1.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
-			this.materialFlatButton1.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
-			// 
-			// materialLabel2
-			// 
-			this.materialLabel2.Depth = 0;
-			this.materialLabel2.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel2.Location = new System.Drawing.Point(6, 98);
-			this.materialLabel2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel2.Name = "materialLabel2";
-			this.materialLabel2.Size = new System.Drawing.Size(63, 19);
-			this.materialLabel2.TabIndex = 2;
-			this.materialLabel2.Text = "Image: ";
-			// 
-			// materialRaisedButton2
-			// 
-			this.materialRaisedButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialRaisedButton2.AutoSize = true;
-			this.materialRaisedButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton2.Depth = 0;
-			this.materialRaisedButton2.Icon = null;
-			this.materialRaisedButton2.Location = new System.Drawing.Point(495, 284);
-			this.materialRaisedButton2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton2.Name = "materialRaisedButton2";
-			this.materialRaisedButton2.Primary = true;
-			this.materialRaisedButton2.Size = new System.Drawing.Size(135, 36);
-			this.materialRaisedButton2.TabIndex = 5;
-			this.materialRaisedButton2.Text = "Patch and save";
-			this.materialRaisedButton2.UseVisualStyleBackColor = true;
-			this.materialRaisedButton2.Click += new System.EventHandler(this.PatchButtonClick);
-			// 
-			// materialLabel3
-			// 
-			this.materialLabel3.Depth = 0;
-			this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel3.Location = new System.Drawing.Point(6, 247);
-			this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel3.Name = "materialLabel3";
-			this.materialLabel3.Size = new System.Drawing.Size(475, 43);
-			this.materialLabel3.TabIndex = 13;
-			this.materialLabel3.Text = "To install themes copy them to the themes folder on your SD card and use the NXTh" +
+            this.LayoutPatchList.BackColor = System.Drawing.Color.White;
+            this.LayoutPatchList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.LayoutPatchList.FormattingEnabled = true;
+            this.LayoutPatchList.Location = new System.Drawing.Point(108, 153);
+            this.LayoutPatchList.Name = "LayoutPatchList";
+            this.LayoutPatchList.Size = new System.Drawing.Size(433, 21);
+            this.LayoutPatchList.TabIndex = 3;
+            this.LayoutPatchList.SelectedIndexChanged += new System.EventHandler(this.LayoutPatchList_SelectedIndexChanged);
+            this.LayoutPatchList.DragDrop += new System.Windows.Forms.DragEventHandler(this.LayoutPatchList_DragDrop);
+            this.LayoutPatchList.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel6
+            // 
+            this.materialLabel6.Depth = 0;
+            this.materialLabel6.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel6.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel6.Location = new System.Drawing.Point(6, 153);
+            this.materialLabel6.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel6.Name = "materialLabel6";
+            this.materialLabel6.Size = new System.Drawing.Size(103, 19);
+            this.materialLabel6.TabIndex = 7;
+            this.materialLabel6.Text = "Layout patch: ";
+            // 
+            // materialFlatButton1
+            // 
+            this.materialFlatButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialFlatButton1.AutoSize = true;
+            this.materialFlatButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialFlatButton1.Depth = 0;
+            this.materialFlatButton1.ForeColor = System.Drawing.Color.White;
+            this.materialFlatButton1.Icon = null;
+            this.materialFlatButton1.Location = new System.Drawing.Point(602, 90);
+            this.materialFlatButton1.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.materialFlatButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialFlatButton1.Name = "materialFlatButton1";
+            this.materialFlatButton1.Primary = false;
+            this.materialFlatButton1.Size = new System.Drawing.Size(32, 36);
+            this.materialFlatButton1.TabIndex = 2;
+            this.materialFlatButton1.Text = "...";
+            this.materialFlatButton1.UseVisualStyleBackColor = true;
+            this.materialFlatButton1.Click += new System.EventHandler(this.BgImageSelectBtn_Click);
+            this.materialFlatButton1.DragDrop += new System.Windows.Forms.DragEventHandler(this.BgImage_DragDrop);
+            this.materialFlatButton1.DragEnter += new System.Windows.Forms.DragEventHandler(this.Shared_FileDragEnter);
+            // 
+            // materialLabel2
+            // 
+            this.materialLabel2.Depth = 0;
+            this.materialLabel2.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel2.Location = new System.Drawing.Point(6, 98);
+            this.materialLabel2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel2.Name = "materialLabel2";
+            this.materialLabel2.Size = new System.Drawing.Size(63, 19);
+            this.materialLabel2.TabIndex = 2;
+            this.materialLabel2.Text = "Image: ";
+            // 
+            // materialRaisedButton2
+            // 
+            this.materialRaisedButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialRaisedButton2.AutoSize = true;
+            this.materialRaisedButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton2.Depth = 0;
+            this.materialRaisedButton2.Icon = null;
+            this.materialRaisedButton2.Location = new System.Drawing.Point(495, 284);
+            this.materialRaisedButton2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton2.Name = "materialRaisedButton2";
+            this.materialRaisedButton2.Primary = true;
+            this.materialRaisedButton2.Size = new System.Drawing.Size(135, 36);
+            this.materialRaisedButton2.TabIndex = 5;
+            this.materialRaisedButton2.Text = "Patch and save";
+            this.materialRaisedButton2.UseVisualStyleBackColor = true;
+            this.materialRaisedButton2.Click += new System.EventHandler(this.PatchButtonClick);
+            // 
+            // materialLabel3
+            // 
+            this.materialLabel3.Depth = 0;
+            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel3.Location = new System.Drawing.Point(6, 247);
+            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel3.Name = "materialLabel3";
+            this.materialLabel3.Size = new System.Drawing.Size(475, 43);
+            this.materialLabel3.TabIndex = 13;
+            this.materialLabel3.Text = "To install themes copy them to the themes folder on your SD card and use the NXTh" +
     "emes Installer homebrew.";
-			// 
-			// materialLabel17
-			// 
-			this.materialLabel17.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // materialLabel17
+            // 
+            this.materialLabel17.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel17.Depth = 0;
-			this.materialLabel17.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel17.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel17.Location = new System.Drawing.Point(13, 122);
-			this.materialLabel17.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel17.Name = "materialLabel17";
-			this.materialLabel17.Size = new System.Drawing.Size(617, 24);
-			this.materialLabel17.TabIndex = 25;
-			this.materialLabel17.Text = "To avoid crashes use 720p DDS images (1280x720 pixels)";
-			this.materialLabel17.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// materialLabel1
-			// 
-			this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel17.Depth = 0;
+            this.materialLabel17.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel17.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel17.Location = new System.Drawing.Point(13, 122);
+            this.materialLabel17.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel17.Name = "materialLabel17";
+            this.materialLabel17.Size = new System.Drawing.Size(617, 24);
+            this.materialLabel17.TabIndex = 25;
+            this.materialLabel17.Text = "To avoid crashes use 720p DDS images (1280x720 pixels)";
+            this.materialLabel17.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // materialLabel1
+            // 
+            this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel1.Depth = 0;
-			this.materialLabel1.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel1.Location = new System.Drawing.Point(3, 6);
-			this.materialLabel1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel1.Name = "materialLabel1";
-			this.materialLabel1.Size = new System.Drawing.Size(633, 45);
-			this.materialLabel1.TabIndex = 14;
-			this.materialLabel1.Text = "Use this page to create themes with the old SZS format, if you don\'t know what yo" +
+            this.materialLabel1.Depth = 0;
+            this.materialLabel1.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel1.Location = new System.Drawing.Point(3, 6);
+            this.materialLabel1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel1.Name = "materialLabel1";
+            this.materialLabel1.Size = new System.Drawing.Size(633, 45);
+            this.materialLabel1.TabIndex = 14;
+            this.materialLabel1.Text = "Use this page to create themes with the old SZS format, if you don\'t know what yo" +
     "u\'re doing it\'s recommended to use nxtheme instead.";
-			this.materialLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// AdvancedPage
-			// 
-			this.AdvancedPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
-			this.AdvancedPage.Controls.Add(this.AdvPanel);
-			this.AdvancedPage.Controls.Add(this.checkBox1);
-			this.AdvancedPage.Controls.Add(this.materialLabel4);
-			this.AdvancedPage.Location = new System.Drawing.Point(4, 22);
-			this.AdvancedPage.Name = "AdvancedPage";
-			this.AdvancedPage.Padding = new System.Windows.Forms.Padding(3);
-			this.AdvancedPage.Size = new System.Drawing.Size(638, 331);
-			this.AdvancedPage.TabIndex = 3;
-			this.AdvancedPage.Text = "Advanced";
-			// 
-			// AdvPanel
-			// 
-			this.AdvPanel.Controls.Add(this.materialRaisedButton7);
-			this.AdvPanel.Controls.Add(this.materialRaisedButton6);
-			this.AdvPanel.Controls.Add(this.materialRaisedButton4);
-			this.AdvPanel.Controls.Add(this.materialLabel5);
-			this.AdvPanel.Controls.Add(this.SzsFileList);
-			this.AdvPanel.Controls.Add(this.materialRaisedButton1);
-			this.AdvPanel.Controls.Add(this.materialRaisedButton5);
-			this.AdvPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.AdvPanel.Enabled = false;
-			this.AdvPanel.Location = new System.Drawing.Point(3, 3);
-			this.AdvPanel.Name = "AdvPanel";
-			this.AdvPanel.Size = new System.Drawing.Size(632, 325);
-			this.AdvPanel.TabIndex = 7;
-			this.AdvPanel.Visible = false;
-			// 
-			// materialRaisedButton7
-			// 
-			this.materialRaisedButton7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.materialRaisedButton7.AutoSize = true;
-			this.materialRaisedButton7.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton7.Depth = 0;
-			this.materialRaisedButton7.Icon = null;
-			this.materialRaisedButton7.Location = new System.Drawing.Point(401, 283);
-			this.materialRaisedButton7.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton7.Name = "materialRaisedButton7";
-			this.materialRaisedButton7.Primary = true;
-			this.materialRaisedButton7.Size = new System.Drawing.Size(79, 36);
-			this.materialRaisedButton7.TabIndex = 4;
-			this.materialRaisedButton7.Text = "File diff";
-			this.materialRaisedButton7.UseVisualStyleBackColor = true;
-			this.materialRaisedButton7.Click += new System.EventHandler(this.materialRaisedButton7_Click);
-			// 
-			// materialRaisedButton6
-			// 
-			this.materialRaisedButton6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.materialRaisedButton6.AutoSize = true;
-			this.materialRaisedButton6.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton6.Depth = 0;
-			this.materialRaisedButton6.Icon = null;
-			this.materialRaisedButton6.Location = new System.Drawing.Point(294, 283);
-			this.materialRaisedButton6.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton6.Name = "materialRaisedButton6";
-			this.materialRaisedButton6.Primary = true;
-			this.materialRaisedButton6.Size = new System.Drawing.Size(104, 36);
-			this.materialRaisedButton6.TabIndex = 3;
-			this.materialRaisedButton6.Text = "Layout diff";
-			this.materialRaisedButton6.UseVisualStyleBackColor = true;
-			this.materialRaisedButton6.Click += new System.EventHandler(this.materialRaisedButton6_Click);
-			// 
-			// materialRaisedButton4
-			// 
-			this.materialRaisedButton4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.materialRaisedButton4.AutoSize = true;
-			this.materialRaisedButton4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton4.Depth = 0;
-			this.materialRaisedButton4.Icon = null;
-			this.materialRaisedButton4.Location = new System.Drawing.Point(181, 283);
-			this.materialRaisedButton4.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton4.Name = "materialRaisedButton4";
-			this.materialRaisedButton4.Primary = true;
-			this.materialRaisedButton4.Size = new System.Drawing.Size(110, 36);
-			this.materialRaisedButton4.TabIndex = 2;
-			this.materialRaisedButton4.Text = "Diff file list";
-			this.materialRaisedButton4.UseVisualStyleBackColor = true;
-			this.materialRaisedButton4.Click += new System.EventHandler(this.materialRaisedButton4_Click);
-			// 
-			// materialLabel5
-			// 
-			this.materialLabel5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // AdvancedPage
+            // 
+            this.AdvancedPage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
+            this.AdvancedPage.Controls.Add(this.AdvPanel);
+            this.AdvancedPage.Controls.Add(this.checkBox1);
+            this.AdvancedPage.Controls.Add(this.materialLabel4);
+            this.AdvancedPage.Location = new System.Drawing.Point(4, 22);
+            this.AdvancedPage.Name = "AdvancedPage";
+            this.AdvancedPage.Padding = new System.Windows.Forms.Padding(3);
+            this.AdvancedPage.Size = new System.Drawing.Size(638, 331);
+            this.AdvancedPage.TabIndex = 3;
+            this.AdvancedPage.Text = "Advanced";
+            // 
+            // AdvPanel
+            // 
+            this.AdvPanel.Controls.Add(this.materialRaisedButton7);
+            this.AdvPanel.Controls.Add(this.materialRaisedButton6);
+            this.AdvPanel.Controls.Add(this.materialRaisedButton4);
+            this.AdvPanel.Controls.Add(this.materialLabel5);
+            this.AdvPanel.Controls.Add(this.SzsFileList);
+            this.AdvPanel.Controls.Add(this.materialRaisedButton1);
+            this.AdvPanel.Controls.Add(this.materialRaisedButton5);
+            this.AdvPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.AdvPanel.Enabled = false;
+            this.AdvPanel.Location = new System.Drawing.Point(3, 3);
+            this.AdvPanel.Name = "AdvPanel";
+            this.AdvPanel.Size = new System.Drawing.Size(632, 325);
+            this.AdvPanel.TabIndex = 7;
+            this.AdvPanel.Visible = false;
+            // 
+            // materialRaisedButton7
+            // 
+            this.materialRaisedButton7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.materialRaisedButton7.AutoSize = true;
+            this.materialRaisedButton7.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton7.Depth = 0;
+            this.materialRaisedButton7.Icon = null;
+            this.materialRaisedButton7.Location = new System.Drawing.Point(401, 283);
+            this.materialRaisedButton7.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton7.Name = "materialRaisedButton7";
+            this.materialRaisedButton7.Primary = true;
+            this.materialRaisedButton7.Size = new System.Drawing.Size(79, 36);
+            this.materialRaisedButton7.TabIndex = 4;
+            this.materialRaisedButton7.Text = "File diff";
+            this.materialRaisedButton7.UseVisualStyleBackColor = true;
+            this.materialRaisedButton7.Click += new System.EventHandler(this.materialRaisedButton7_Click);
+            // 
+            // materialRaisedButton6
+            // 
+            this.materialRaisedButton6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.materialRaisedButton6.AutoSize = true;
+            this.materialRaisedButton6.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton6.Depth = 0;
+            this.materialRaisedButton6.Icon = null;
+            this.materialRaisedButton6.Location = new System.Drawing.Point(294, 283);
+            this.materialRaisedButton6.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton6.Name = "materialRaisedButton6";
+            this.materialRaisedButton6.Primary = true;
+            this.materialRaisedButton6.Size = new System.Drawing.Size(104, 36);
+            this.materialRaisedButton6.TabIndex = 3;
+            this.materialRaisedButton6.Text = "Layout diff";
+            this.materialRaisedButton6.UseVisualStyleBackColor = true;
+            this.materialRaisedButton6.Click += new System.EventHandler(this.materialRaisedButton6_Click);
+            // 
+            // materialRaisedButton4
+            // 
+            this.materialRaisedButton4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.materialRaisedButton4.AutoSize = true;
+            this.materialRaisedButton4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton4.Depth = 0;
+            this.materialRaisedButton4.Icon = null;
+            this.materialRaisedButton4.Location = new System.Drawing.Point(181, 283);
+            this.materialRaisedButton4.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton4.Name = "materialRaisedButton4";
+            this.materialRaisedButton4.Primary = true;
+            this.materialRaisedButton4.Size = new System.Drawing.Size(110, 36);
+            this.materialRaisedButton4.TabIndex = 2;
+            this.materialRaisedButton4.Text = "Diff file list";
+            this.materialRaisedButton4.UseVisualStyleBackColor = true;
+            this.materialRaisedButton4.Click += new System.EventHandler(this.materialRaisedButton4_Click);
+            // 
+            // materialLabel5
+            // 
+            this.materialLabel5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel5.Depth = 0;
-			this.materialLabel5.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel5.Location = new System.Drawing.Point(3, 0);
-			this.materialLabel5.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel5.Name = "materialLabel5";
-			this.materialLabel5.Size = new System.Drawing.Size(626, 23);
-			this.materialLabel5.TabIndex = 7;
-			this.materialLabel5.Text = "Files in the SZS (right click to replace or extract):";
-			// 
-			// SzsFileList
-			// 
-			this.SzsFileList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.materialLabel5.Depth = 0;
+            this.materialLabel5.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel5.Location = new System.Drawing.Point(3, 0);
+            this.materialLabel5.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel5.Name = "materialLabel5";
+            this.materialLabel5.Size = new System.Drawing.Size(626, 23);
+            this.materialLabel5.TabIndex = 7;
+            this.materialLabel5.Text = "Files in the SZS (right click to replace or extract):";
+            // 
+            // SzsFileList
+            // 
+            this.SzsFileList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.SzsFileList.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
-			this.SzsFileList.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.SzsFileList.ContextMenuStrip = this.contextMenuStrip1;
-			this.SzsFileList.ForeColor = System.Drawing.Color.White;
-			this.SzsFileList.FormattingEnabled = true;
-			this.SzsFileList.Location = new System.Drawing.Point(3, 26);
-			this.SzsFileList.Name = "SzsFileList";
-			this.SzsFileList.Size = new System.Drawing.Size(626, 234);
-			this.SzsFileList.Sorted = true;
-			this.SzsFileList.TabIndex = 0;
-			// 
-			// contextMenuStrip1
-			// 
-			this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SzsFileList.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.SzsFileList.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.SzsFileList.ContextMenuStrip = this.contextMenuStrip1;
+            this.SzsFileList.ForeColor = System.Drawing.Color.White;
+            this.SzsFileList.FormattingEnabled = true;
+            this.SzsFileList.Location = new System.Drawing.Point(3, 26);
+            this.SzsFileList.Name = "SzsFileList";
+            this.SzsFileList.Size = new System.Drawing.Size(626, 234);
+            this.SzsFileList.Sorted = true;
+            this.SzsFileList.TabIndex = 0;
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.extractToolStripMenuItem,
             this.replaceToolStripMenuItem});
-			this.contextMenuStrip1.Name = "contextMenuStrip1";
-			this.contextMenuStrip1.Size = new System.Drawing.Size(116, 48);
-			// 
-			// extractToolStripMenuItem
-			// 
-			this.extractToolStripMenuItem.Name = "extractToolStripMenuItem";
-			this.extractToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-			this.extractToolStripMenuItem.Text = "Extract";
-			this.extractToolStripMenuItem.Click += new System.EventHandler(this.extractToolStripMenuItem_Click);
-			// 
-			// replaceToolStripMenuItem
-			// 
-			this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
-			this.replaceToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-			this.replaceToolStripMenuItem.Text = "Replace";
-			this.replaceToolStripMenuItem.Click += new System.EventHandler(this.replaceToolStripMenuItem_Click);
-			// 
-			// materialRaisedButton1
-			// 
-			this.materialRaisedButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialRaisedButton1.AutoSize = true;
-			this.materialRaisedButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton1.Depth = 0;
-			this.materialRaisedButton1.Icon = null;
-			this.materialRaisedButton1.Location = new System.Drawing.Point(497, 283);
-			this.materialRaisedButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton1.Name = "materialRaisedButton1";
-			this.materialRaisedButton1.Primary = true;
-			this.materialRaisedButton1.Size = new System.Drawing.Size(132, 36);
-			this.materialRaisedButton1.TabIndex = 5;
-			this.materialRaisedButton1.Text = "Save edited SZS";
-			this.materialRaisedButton1.UseVisualStyleBackColor = true;
-			this.materialRaisedButton1.Click += new System.EventHandler(this.materialRaisedButton1_Click);
-			// 
-			// materialRaisedButton5
-			// 
-			this.materialRaisedButton5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.materialRaisedButton5.AutoSize = true;
-			this.materialRaisedButton5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialRaisedButton5.Depth = 0;
-			this.materialRaisedButton5.Icon = null;
-			this.materialRaisedButton5.Location = new System.Drawing.Point(3, 283);
-			this.materialRaisedButton5.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton5.Name = "materialRaisedButton5";
-			this.materialRaisedButton5.Primary = true;
-			this.materialRaisedButton5.Size = new System.Drawing.Size(175, 36);
-			this.materialRaisedButton5.TabIndex = 1;
-			this.materialRaisedButton5.Text = "Texture usage count";
-			this.materialRaisedButton5.UseVisualStyleBackColor = true;
-			this.materialRaisedButton5.Click += new System.EventHandler(this.materialRaisedButton5_Click);
-			// 
-			// checkBox1
-			// 
-			this.checkBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.checkBox1.AutoSize = true;
-			this.checkBox1.ForeColor = System.Drawing.Color.White;
-			this.checkBox1.Location = new System.Drawing.Point(494, 28);
-			this.checkBox1.Name = "checkBox1";
-			this.checkBox1.Size = new System.Drawing.Size(135, 17);
-			this.checkBox1.TabIndex = 0;
-			this.checkBox1.Text = "Enable advanced tools";
-			this.checkBox1.UseVisualStyleBackColor = true;
-			this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
-			// 
-			// materialLabel4
-			// 
-			this.materialLabel4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(139, 48);
+            // 
+            // extractToolStripMenuItem
+            // 
+            this.extractToolStripMenuItem.Name = "extractToolStripMenuItem";
+            this.extractToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
+            this.extractToolStripMenuItem.Text = "Extract";
+            this.extractToolStripMenuItem.Click += new System.EventHandler(this.extractToolStripMenuItem_Click);
+            // 
+            // replaceToolStripMenuItem
+            // 
+            this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
+            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
+            this.replaceToolStripMenuItem.Text = "Replace";
+            this.replaceToolStripMenuItem.Click += new System.EventHandler(this.replaceToolStripMenuItem_Click);
+            // 
+            // materialRaisedButton1
+            // 
+            this.materialRaisedButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialRaisedButton1.AutoSize = true;
+            this.materialRaisedButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton1.Depth = 0;
+            this.materialRaisedButton1.Icon = null;
+            this.materialRaisedButton1.Location = new System.Drawing.Point(497, 283);
+            this.materialRaisedButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton1.Name = "materialRaisedButton1";
+            this.materialRaisedButton1.Primary = true;
+            this.materialRaisedButton1.Size = new System.Drawing.Size(132, 36);
+            this.materialRaisedButton1.TabIndex = 5;
+            this.materialRaisedButton1.Text = "Save edited SZS";
+            this.materialRaisedButton1.UseVisualStyleBackColor = true;
+            this.materialRaisedButton1.Click += new System.EventHandler(this.materialRaisedButton1_Click);
+            // 
+            // materialRaisedButton5
+            // 
+            this.materialRaisedButton5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.materialRaisedButton5.AutoSize = true;
+            this.materialRaisedButton5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialRaisedButton5.Depth = 0;
+            this.materialRaisedButton5.Icon = null;
+            this.materialRaisedButton5.Location = new System.Drawing.Point(3, 283);
+            this.materialRaisedButton5.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton5.Name = "materialRaisedButton5";
+            this.materialRaisedButton5.Primary = true;
+            this.materialRaisedButton5.Size = new System.Drawing.Size(175, 36);
+            this.materialRaisedButton5.TabIndex = 1;
+            this.materialRaisedButton5.Text = "Texture usage count";
+            this.materialRaisedButton5.UseVisualStyleBackColor = true;
+            this.materialRaisedButton5.Click += new System.EventHandler(this.materialRaisedButton5_Click);
+            // 
+            // checkBox1
+            // 
+            this.checkBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.checkBox1.AutoSize = true;
+            this.checkBox1.ForeColor = System.Drawing.Color.White;
+            this.checkBox1.Location = new System.Drawing.Point(494, 28);
+            this.checkBox1.Name = "checkBox1";
+            this.checkBox1.Size = new System.Drawing.Size(135, 17);
+            this.checkBox1.TabIndex = 0;
+            this.checkBox1.Text = "Enable advanced tools";
+            this.checkBox1.UseVisualStyleBackColor = true;
+            this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            // 
+            // materialLabel4
+            // 
+            this.materialLabel4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel4.Depth = 0;
-			this.materialLabel4.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel4.Location = new System.Drawing.Point(0, 3);
-			this.materialLabel4.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel4.Name = "materialLabel4";
-			this.materialLabel4.Size = new System.Drawing.Size(638, 46);
-			this.materialLabel4.TabIndex = 6;
-			this.materialLabel4.Text = "Advanced tools allow you to manually edit the SZS and more to create custom patch" +
+            this.materialLabel4.Depth = 0;
+            this.materialLabel4.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel4.Location = new System.Drawing.Point(0, 3);
+            this.materialLabel4.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel4.Name = "materialLabel4";
+            this.materialLabel4.Size = new System.Drawing.Size(638, 46);
+            this.materialLabel4.TabIndex = 6;
+            this.materialLabel4.Text = "Advanced tools allow you to manually edit the SZS and more to create custom patch" +
     "es, enable them only if you know what you\'re doing";
-			// 
-			// materialTabSelector1
-			// 
-			this.materialTabSelector1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // materialTabSelector1
+            // 
+            this.materialTabSelector1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialTabSelector1.BaseTabControl = this.materialTabControl1;
-			this.materialTabSelector1.Depth = 0;
-			this.materialTabSelector1.Location = new System.Drawing.Point(-1, 59);
-			this.materialTabSelector1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialTabSelector1.Name = "materialTabSelector1";
-			this.materialTabSelector1.Size = new System.Drawing.Size(646, 30);
-			this.materialTabSelector1.TabIndex = 0;
-			this.materialTabSelector1.Text = "materialTabSelector1";
-			// 
-			// lblDebug
-			// 
-			this.lblDebug.AutoSize = true;
-			this.lblDebug.BackColor = System.Drawing.Color.Transparent;
-			this.lblDebug.ForeColor = System.Drawing.Color.Red;
-			this.lblDebug.Location = new System.Drawing.Point(3, 6);
-			this.lblDebug.Name = "lblDebug";
-			this.lblDebug.Size = new System.Drawing.Size(354, 13);
-			this.lblDebug.TabIndex = 13;
-			this.lblDebug.Text = "Debug build: Generated NXThemes may not install with the public installer";
-			this.lblDebug.Visible = false;
-			// 
-			// Form1
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(645, 454);
-			this.Controls.Add(this.lblDebug);
-			this.Controls.Add(this.materialTabSelector1);
-			this.Controls.Add(this.materialTabControl1);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(645, 439);
-			this.Name = "Form1";
-			this.Text = "Switch Theme Injector";
-			this.Load += new System.EventHandler(this.Form1_Load);
-			this.materialTabControl1.ResumeLayout(false);
-			this.NXThemePage.ResumeLayout(false);
-			this.NXThemePage.PerformLayout();
-			this.grpHomeExtra.ResumeLayout(false);
-			this.grpLockExtra.ResumeLayout(false);
-			this.ExtractPage.ResumeLayout(false);
-			this.ExtractPage.PerformLayout();
-			this.InfoPage.ResumeLayout(false);
-			this.InfoPage.PerformLayout();
-			this.InjectPage.ResumeLayout(false);
-			this.InjectPage.PerformLayout();
-			this.AdvancedPage.ResumeLayout(false);
-			this.AdvancedPage.PerformLayout();
-			this.AdvPanel.ResumeLayout(false);
-			this.AdvPanel.PerformLayout();
-			this.contextMenuStrip1.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.materialTabSelector1.BaseTabControl = this.materialTabControl1;
+            this.materialTabSelector1.Depth = 0;
+            this.materialTabSelector1.Location = new System.Drawing.Point(-1, 59);
+            this.materialTabSelector1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialTabSelector1.Name = "materialTabSelector1";
+            this.materialTabSelector1.Size = new System.Drawing.Size(715, 30);
+            this.materialTabSelector1.TabIndex = 0;
+            this.materialTabSelector1.Text = "materialTabSelector1";
+            // 
+            // lblDebug
+            // 
+            this.lblDebug.AutoSize = true;
+            this.lblDebug.BackColor = System.Drawing.Color.Transparent;
+            this.lblDebug.ForeColor = System.Drawing.Color.Red;
+            this.lblDebug.Location = new System.Drawing.Point(3, 6);
+            this.lblDebug.Name = "lblDebug";
+            this.lblDebug.Size = new System.Drawing.Size(354, 13);
+            this.lblDebug.TabIndex = 13;
+            this.lblDebug.Text = "Debug build: Generated NXThemes may not install with the public installer";
+            this.lblDebug.Visible = false;
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(714, 497);
+            this.Controls.Add(this.lblDebug);
+            this.Controls.Add(this.materialTabSelector1);
+            this.Controls.Add(this.materialTabControl1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(714, 469);
+            this.Name = "Form1";
+            this.Text = "Switch Theme Injector";
+            this.Load += new System.EventHandler(this.Form1_Load);
+            this.materialTabControl1.ResumeLayout(false);
+            this.NXThemePage.ResumeLayout(false);
+            this.NXThemePage.PerformLayout();
+            this.grpHomeExtra.ResumeLayout(false);
+            this.grpLockExtra.ResumeLayout(false);
+            this.ExtractPage.ResumeLayout(false);
+            this.ExtractPage.PerformLayout();
+            this.InfoPage.ResumeLayout(false);
+            this.InfoPage.PerformLayout();
+            this.InjectPage.ResumeLayout(false);
+            this.InjectPage.PerformLayout();
+            this.AdvancedPage.ResumeLayout(false);
+            this.AdvancedPage.PerformLayout();
+            this.AdvPanel.ResumeLayout(false);
+            this.AdvPanel.PerformLayout();
+            this.contextMenuStrip1.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -1302,6 +1341,9 @@
 		private MaterialSkin.Controls.MaterialLabel lblAppletIcons;
 		private System.Windows.Forms.Label lblDebug;
 		private System.Windows.Forms.Button button1;
+		private System.Windows.Forms.Button btnApplet9;		
+		private System.Windows.Forms.Button btnApplet8;		
+		private System.Windows.Forms.Button btnApplet7;
 		private System.Windows.Forms.Button btnApplet6;
 		private System.Windows.Forms.Button btnApplet5;
 		private System.Windows.Forms.Button btnApplet4;
@@ -1324,4 +1366,3 @@
 		private MaterialSkin.Controls.MaterialRaisedButton ExtractNxthemeBtn;
 	}
 }
-

--- a/SwitchThemes/Form1.cs
+++ b/SwitchThemes/Form1.cs
@@ -597,7 +597,7 @@ namespace SwitchThemes
 
 		private void HomeAppletIcoButtonsInit()
 		{
-			var btns = new List<Button> { btnApplet1, btnApplet2, btnApplet3, btnApplet4, btnApplet5, btnApplet6 };
+			var btns = new List<Button> { btnApplet1, btnApplet2, btnApplet3, btnApplet4, btnApplet5, btnApplet6, btnApplet7, btnApplet8, btnApplet9  };
 			int i = 0;
 			foreach (var p in TextureReplacement.ResidentMenu)
 			{

--- a/SwitchThemesCommon/PatchTemplate.cs
+++ b/SwitchThemesCommon/PatchTemplate.cs
@@ -19,7 +19,7 @@ namespace SwitchThemes.Common
 		*at least one of these two files must be in the theme for it to be valid*
 		Home-menu only files: these files can only be present if the theme targets the home menu, all of them are optional.
 			common.json - a layout to be applied to the common.szs file
-			album.dds/png, news.dds/png, shop.dds/png, controller.dds/png, settings.dds/png, power.dds/png - custom applet icons
+			album.dds/png, news.dds/png, shop.dds/png, card.dds/png, controller.dds/png, nso.dds/png, settings.dds/png, share.dds/png, power.dds/png - custom applet icons
 		Lock-screen only files:
 			lock.dds/png - custom home icon
 
@@ -337,6 +337,42 @@ namespace SwitchThemes.Common
 			}
 		};
 
+		readonly static LayoutFilePatch NsoPatch = new LayoutFilePatch()
+		{
+			FileName = "blyt/RdtBtnLR.bflyt",
+			Patches = new PanePatch[]
+			{
+				new PanePatch { PaneName = "P_LR_00", Size = new Vector2(64,56)},
+				new PanePatch { PaneName = "P_LR_01", Visible = false },
+			}
+		};
+
+		readonly static LayoutFilePatch SplayPatch = new LayoutFilePatch()
+		{
+			FileName = "blyt/RdtBtnSplay.bflyt",
+			Patches = new PanePatch[]
+			{
+				new PanePatch { PaneName = "P_Pict_00", Size = new Vector2(64,56),
+				UsdPatches = new List<UsdPatch>() { new UsdPatch() {PropName = "C_W", PropValues = new string[] { "100","100","100","100" }, type = 1 } }},
+				new PanePatch { PaneName = "N_Wave", Visible = false },
+				new PanePatch { PaneName = "P_Pict_01", Visible = false },
+				new PanePatch { PaneName = "P_Pict_02", Visible = false },
+				new PanePatch { PaneName = "P_Pict_03", Visible = false }
+			}
+		};
+
+		readonly static LayoutFilePatch VgcPatch = new LayoutFilePatch()
+		{
+			FileName = "blyt/RdtBtnVgc.bflyt",
+			Patches = new PanePatch[]
+			{
+				new PanePatch { PaneName = "P_Pict_00", Size = new Vector2(64,56),
+				UsdPatches = new List<UsdPatch>() { new UsdPatch() {PropName = "C_W", PropValues = new string[] { "100","100","100","100" }, type = 1 } }},
+				new PanePatch { PaneName = "P_00", Visible = false },
+				new PanePatch { PaneName = "P_01", Visible = false },
+			}
+		};
+
 		readonly static LayoutFilePatch LockPatch = new LayoutFilePatch()
 		{
 			FileName = "blyt/EntBtnResumeSystemApplet.bflyt",
@@ -371,12 +407,15 @@ namespace SwitchThemes.Common
 
 		readonly public static List<TextureReplacement> ResidentMenu = new List<TextureReplacement>
 		{
-			new TextureReplacement("album",     new[] {"RdtIcoPvr_00^s"},	0x5050505, "blyt/RdtBtnPvr.bflyt",		"P_Pict_00",		64,56, AlbumPatch),
-			new TextureReplacement("news",      newsTextures,				0x5050505, "blyt/RdtBtnNtf.bflyt",		"P_PictNtf_00",		64,56, NtfPatch),
-			new TextureReplacement("shop",      new[] {"RdtIcoShop^s"},		0x5050505, "blyt/RdtBtnShop.bflyt",		"P_Pict",			64,56, ShopPatch),
-			new TextureReplacement("controller",new[] {"RdtIcoCtrl_00^s"},	0x5050505, "blyt/RdtBtnCtrl.bflyt",		"P_Form",			64,56, CtrlPatch),
-			new TextureReplacement("settings",  new[] {"RdtIcoSet^s"},		0x5050505, "blyt/RdtBtnSet.bflyt",		"P_Pict",			64,56, SetPatch),
-			new TextureReplacement("power",     new[] {"RdtIcoPwrForm^s"},	0x5050505, "blyt/RdtBtnPow.bflyt",		"P_Pict_00",		64,56, PowPatch),
+			new TextureReplacement("album",     new[] {"RdtIcoPvr_00^s"},			0x5050505, "blyt/RdtBtnPvr.bflyt",		"P_Pict_00",		64,56, AlbumPatch),
+			new TextureReplacement("news",      newsTextures,						0x5050505, "blyt/RdtBtnNtf.bflyt",		"P_PictNtf_00",		64,56, NtfPatch),
+			new TextureReplacement("shop",      new[] {"RdtIcoShop^s"},				0x5050505, "blyt/RdtBtnShop.bflyt",		"P_Pict",			64,56, ShopPatch),
+			new TextureReplacement("controller",new[] {"RdtIcoCtrl_00^s"},			0x5050505, "blyt/RdtBtnCtrl.bflyt",		"P_Form",			64,56, CtrlPatch),
+			new TextureReplacement("settings",  new[] {"RdtIcoSet^s"},				0x5050505, "blyt/RdtBtnSet.bflyt",		"P_Pict",			64,56, SetPatch),
+			new TextureReplacement("power",     new[] {"RdtIcoPwrForm^s"},			0x5050505, "blyt/RdtBtnPow.bflyt",		"P_Pict_00",		64,56, PowPatch),
+			new TextureReplacement("nso",       new[] {"RdtIcoLR_00^s"},			0x5050505, "blyt/RdtBtnLR.bflyt",		"P_LR_00",			64,56, NsoPatch),
+			new TextureReplacement("card",      new[] {"RdtIcoHomeVgc^s"},			0x5050505, "blyt/RdtBtnVgc.bflyt",		"P_Pict_00",		64,56, VgcPatch),
+			new TextureReplacement("share",     new[] {"RdtIcoHomeSplayFrame^s"},	0x5050505, "blyt/RdtBtnSplay.bflyt",	"P_Pict_00",		64,56, SplayPatch),
 		};
 
 		readonly public static List<TextureReplacement> Entrance = new List<TextureReplacement>

--- a/SwitchThemesNX/source/SwitchThemesCommon/Layouts/DefaultTemplates.cpp
+++ b/SwitchThemesNX/source/SwitchThemesCommon/Layouts/DefaultTemplates.cpp
@@ -250,6 +250,9 @@ namespace Patches::textureReplacement {
 	static constexpr string_view CtrlPatch	= "{\"FileName\":\"blyt/RdtBtnCtrl.bflyt\",\"Patches\":[{\"PaneName\":\"P_Form\",\"Size\":{\"X\":64.0,\"Y\":56.0},\"UsdPatches\":[{\"PropName\":\"C_W\",\"PropValues\":[\"100\",\"100\",\"100\",\"100\"],\"type\":1}]},{\"PaneName\":\"P_Stick\",\"Visible\":false},{\"PaneName\":\"P_Y\",\"Visible\":false},{\"PaneName\":\"P_X\",\"Visible\":false},{\"PaneName\":\"P_A\",\"Visible\":false},{\"PaneName\":\"P_B\",\"Visible\":false}]}";
 	static constexpr string_view SetPatch	= "{\"FileName\":\"blyt/RdtBtnSet.bflyt\",\"Patches\":[{\"PaneName\":\"P_Pict\",\"Size\":{\"X\":64.0,\"Y\":56.0},\"UsdPatches\":[{\"PropName\":\"C_W\",\"PropValues\":[\"100\",\"100\",\"100\",\"100\"],\"type\":1}]}]}";
 	static constexpr string_view PowPatch	= "{\"FileName\":\"blyt/RdtBtnPow.bflyt\",\"Patches\":[{\"PaneName\":\"P_Pict_00\",\"Size\":{\"X\":64.0,\"Y\":56.0},\"UsdPatches\":[{\"PropName\":\"C_W\",\"PropValues\":[\"100\",\"100\",\"100\",\"100\"],\"type\":1}]}]}";
+	static constexpr string_view NsoPatch   = "{\"FileName\":\"blyt/RdtBtnLR.bflyt\",\"Patches\":[{\"PaneName\":\"P_LR_00\",\"Size\":{\"X\":64.0,\"Y\":56.0}},{\"PaneName\":\"P_LR_01\",\"Visible\":false}]}";
+	static constexpr string_view VgcPatch	= "{\"FileName\":\"blyt/RdtBtnVgc.bflyt\",\"Patches\":[{\"PaneName\":\"P_Pict_00\",\"Size\":{\"X\":64.0,\"Y\":56.0},\"UsdPatches\":[{\"PropName\":\"C_W\",\"PropValues\":[\"100\",\"100\",\"100\",\"100\"],\"type\":1}]},{\"PaneName\":\"P_00\",\"Visible\":false},{\"PaneName\":\"P_01\",\"Visible\":false}]}";
+	static constexpr string_view SplayPatch = "{\"FileName\":\"blyt/RdtBtnSplay.bflyt\",\"Patches\":[{\"PaneName\":\"P_Pict_00\",\"Size\":{\"X\":64.0,\"Y\":56.0},\"UsdPatches\":[{\"PropName\":\"C_W\",\"PropValues\":[\"100\",\"100\",\"100\",\"100\"],\"type\":1}]},{\"PaneName\":\"N_Wave\",\"Visible\":false},{\"PaneName\":\"P_Pict_01\",\"Visible\":false},{\"PaneName\":\"P_Pict_02\",\"Visible\":false},{\"PaneName\":\"P_Pict_03\",\"Visible\":false}]}";
 	static constexpr string_view LockPatch	= "{\"FileName\":\"blyt/EntBtnResumeSystemApplet.bflyt\",\"Patches\":[{\"PaneName\":\"P_PictHome\",\"Position\":{\"X\":0.0,\"Y\":0.0,\"Z\":0.0},\"Size\":{\"X\":184.0,\"Y\":168.0}}]}";
 
 	static LayoutFilePatch GetPatch(const string_view &str)
@@ -265,6 +268,9 @@ namespace Patches::textureReplacement {
 		{"controller",{"RdtIcoCtrl_00^s"},							0x5050505, "blyt/RdtBtnCtrl.bflyt",    "P_Form",		64,56, GetPatch(CtrlPatch)	},
 		{"settings",  {"RdtIcoSet^s"},								0x5050505, "blyt/RdtBtnSet.bflyt",     "P_Pict",		64,56, GetPatch(SetPatch)	},
 		{"power",     {"RdtIcoPwrForm^s"},							0x5050505, "blyt/RdtBtnPow.bflyt",     "P_Pict_00",		64,56, GetPatch(PowPatch)	},
+		{"nso",       {"RdtIcoLR_00^s"},							0x5050505, "blyt/RdtBtnLR.bflyt",      "P_LR_00",		64,56, GetPatch(NsoPatch)	},
+		{"card",      {"RdtIcoHomeVgc^s"},							0x5050505, "blyt/RdtBtnVgc.bflyt",     "P_Pict_00",		64,56, GetPatch(VgcPatch)	},
+		{"share",     {"RdtIcoHomeSplayFrame^s"},					0x5050505, "blyt/RdtBtnSplay.bflyt",   "P_Pict_00",		64,56, GetPatch(SplayPatch)	},
 	};
 
 	static vector<TextureReplacement> Entrance


### PR DESCRIPTION
This pull request is based on changes originally made by @ELY3M.

It adds support for custom icons for GameShare, Virtual Game Cart, and NSO applets. 

The Winforms changes are pretty much @ELY3M's unmodified, while rest others I re-implemented, although the result is almost exactly the same. I did deliberately retain the same icon file naming as @ELY3M used since it seemed reasonable. 

One note is that if replacing the NSO icon, no effort is made to change the background circle from red. If a theme creator wants the color changed, it much be included in the layout JSON patch. I suspect that many layouts that choose to keep the NSO icon are likely to adjust the background color anyway to avoid it standing out so much. 

I've tested the resulting installer, and this all seems to work fine. I've tried creating a theme with custom icons for all applets, and my favorite background image, along with installing themes for all the other themeable screens. This all worked fine on 20.0.1. I've even tested with games running heavy applets like the eShop or web browser, and nothing seemed to break. 

I've also tested installing a theme with the replacements for the new icons on 19.0.1. This works fine, with NSO replaced as expected, although it gives some scary warnings about possibly crashing because it couldn't patch the other two new icons (because they don't exist on this older version).